### PR TITLE
[fix-overhead-model-latency]

### DIFF
--- a/recommendation/api/Dockerfile
+++ b/recommendation/api/Dockerfile
@@ -17,6 +17,7 @@ COPY src/pcreco/core/utils/* pcreco/core/utils/
 COPY src/pcreco/models/reco/* pcreco/models/reco/
 COPY src/pcreco/utils/db/* pcreco/utils/db/
 COPY src/pcreco/utils/secrets/* pcreco/utils/secrets/
+COPY src/pcreco/utils/ai_platform/* pcreco/utils/ai_platform/
 COPY src/pcreco/utils/* pcreco/utils/
 
 # Install production dependencies.

--- a/recommendation/api/src/app.py
+++ b/recommendation/api/src/app.py
@@ -94,7 +94,6 @@ def recommendation(user_id: int):
     longitude = request.args.get("longitude", None)
     latitude = request.args.get("latitude", None)
     post_args_json = request.get_json() if request.method == "POST" else None
-
     user = User(user_id, longitude, latitude)
     input_reco = RecommendationIn(post_args_json) if post_args_json else None
     scoring = Scoring(user, recommendation_in=input_reco)
@@ -119,11 +118,9 @@ def playlist_recommendation(user_id: int):
     longitude = request.args.get("longitude", None)
     latitude = request.args.get("latitude", None)
     post_args_json = request.get_json() if request.method == "POST" else None
-
     user = User(user_id, longitude, latitude)
     input_reco = RecommendationIn(post_args_json) if post_args_json else None
     scoring = Scoring(user, recommendation_in=input_reco)
-
     user_recommendations = scoring.get_recommendation()
     scoring.save_recommendation(user_recommendations)
     return jsonify(

--- a/recommendation/api/src/pcreco/utils/ai_platform/get_ai_platform_service.py
+++ b/recommendation/api/src/pcreco/utils/ai_platform/get_ai_platform_service.py
@@ -2,7 +2,8 @@ from google.auth.exceptions import DefaultCredentialsError
 from google.api_core.client_options import ClientOptions
 from googleapiclient import discovery
 
-def get_ai_platform_service(MODEL_END_POINT,default=None):
+
+def get_ai_platform_service(MODEL_END_POINT, default=None):
     try:
         client = ClientOptions(api_endpoint=MODEL_END_POINT)
         ai_platform_service = discovery.build(

--- a/recommendation/api/src/pcreco/utils/ai_platform/get_ai_platform_service.py
+++ b/recommendation/api/src/pcreco/utils/ai_platform/get_ai_platform_service.py
@@ -1,0 +1,16 @@
+from google.auth.exceptions import DefaultCredentialsError
+from google.api_core.client_options import ClientOptions
+from googleapiclient import discovery
+
+def get_ai_platform_service(MODEL_END_POINT,default=None):
+    try:
+        client = ClientOptions(api_endpoint=MODEL_END_POINT)
+        ai_platform_service = discovery.build(
+            "ml",
+            "v1",
+            client_options=client,
+            cache_discovery=False,
+        )
+        return ai_platform_service
+    except DefaultCredentialsError:
+        return default

--- a/recommendation/api/src/pcreco/utils/env_vars.py
+++ b/recommendation/api/src/pcreco/utils/env_vars.py
@@ -4,11 +4,21 @@ import time
 from typing import Any
 
 from pcreco.utils.secrets.access_gcp_secrets import access_secret
+from google.api_core.client_options import ClientOptions
+from googleapiclient import discovery
 from loguru import logger
 
 GCP_PROJECT = os.environ.get("GCP_PROJECT")
 ENV_SHORT_NAME = os.environ.get("ENV_SHORT_NAME", "dev")
 MODEL_REGION = os.environ.get("MODEL_REGION")
+
+MODEL_END_POINT = f"https://{MODEL_REGION}-ml.googleapis.com"
+AI_PLATFORM_SERVICE = discovery.build(
+    "ml",
+    "v1",
+    client_options=ClientOptions(api_endpoint=MODEL_END_POINT),
+    cache_discovery=False,
+)
 # SQL
 SQL_BASE = os.environ.get("SQL_BASE")
 SQL_BASE_USER = os.environ.get("SQL_BASE_USER")

--- a/recommendation/api/src/pcreco/utils/env_vars.py
+++ b/recommendation/api/src/pcreco/utils/env_vars.py
@@ -4,8 +4,7 @@ import time
 from typing import Any
 
 from pcreco.utils.secrets.access_gcp_secrets import access_secret
-from google.api_core.client_options import ClientOptions
-from googleapiclient import discovery
+from pcreco.utils.ai_platform.get_ai_platform_service import get_ai_platform_service
 from loguru import logger
 
 GCP_PROJECT = os.environ.get("GCP_PROJECT")
@@ -13,12 +12,7 @@ ENV_SHORT_NAME = os.environ.get("ENV_SHORT_NAME", "dev")
 MODEL_REGION = os.environ.get("MODEL_REGION")
 
 MODEL_END_POINT = f"https://{MODEL_REGION}-ml.googleapis.com"
-AI_PLATFORM_SERVICE = discovery.build(
-    "ml",
-    "v1",
-    client_options=ClientOptions(api_endpoint=MODEL_END_POINT),
-    cache_discovery=False,
-)
+AI_PLATFORM_SERVICE = get_ai_platform_service(MODEL_END_POINT)
 # SQL
 SQL_BASE = os.environ.get("SQL_BASE")
 SQL_BASE_USER = os.environ.get("SQL_BASE_USER")


### PR DESCRIPTION
- Refacto : Create object 'AI_platform_services' only once , not everytime we call 'predict()' 
-> cf. [GCP_doc](https://cloud.google.com/architecture/best-practices-for-ml-performance-cost#reuse_the_authenticated_service_object_in_the_client_object)