### PR TITLE
[fix-add-model-metadate-to-pcreco-output]

### DIFF
--- a/recommendation/api/src/app.py
+++ b/recommendation/api/src/app.py
@@ -98,7 +98,7 @@ def recommendation(user_id: int):
     input_reco = RecommendationIn(post_args_json) if post_args_json else None
     scoring = Scoring(user, recommendation_in=input_reco)
 
-    user_recommendations = scoring.get_recommendation()
+    user_recommendations, model_version_id, model_name = scoring.get_recommendation()
     scoring.save_recommendation(user_recommendations)
     return jsonify(
         {
@@ -106,6 +106,8 @@ def recommendation(user_id: int):
             "AB_test": user.group_id if AB_TESTING else "default",
             "reco_origin": "cold_start" if scoring.iscoldstart else "algo",
             "model_name": scoring.model_name if not scoring.iscoldstart else None,
+            "ai_vertex:model_version_id": model_version_id,
+            "ai_vertex:model_name": model_name,
         }
     )
 

--- a/recommendation/api/src/app.py
+++ b/recommendation/api/src/app.py
@@ -98,7 +98,7 @@ def recommendation(user_id: int):
     input_reco = RecommendationIn(post_args_json) if post_args_json else None
     scoring = Scoring(user, recommendation_in=input_reco)
 
-    user_recommendations, model_version_id, model_name = scoring.get_recommendation()
+    user_recommendations = scoring.get_recommendation()
     scoring.save_recommendation(user_recommendations)
     return jsonify(
         {
@@ -106,8 +106,8 @@ def recommendation(user_id: int):
             "AB_test": user.group_id if AB_TESTING else "default",
             "reco_origin": "cold_start" if scoring.iscoldstart else "algo",
             "model_name": scoring.model_name if not scoring.iscoldstart else None,
-            "ai_vertex:model_version_id": model_version_id,
-            "ai_vertex:model_name": model_name,
+            "ai_vertex:model_version_id": scoring.scoring.model_version,
+            "ai_vertex:model_display_name": scoring.scoring.model_display_name,
         }
     )
 

--- a/recommendation/api/src/app.py
+++ b/recommendation/api/src/app.py
@@ -105,9 +105,8 @@ def recommendation(user_id: int):
             "recommended_offers": user_recommendations,
             "AB_test": user.group_id if AB_TESTING else "default",
             "reco_origin": "cold_start" if scoring.iscoldstart else "algo",
-            "model_name": scoring.model_name if not scoring.iscoldstart else None,
-            "ai_vertex:model_version_id": scoring.scoring.model_version,
-            "ai_vertex:model_display_name": scoring.scoring.model_display_name,
+            "model_version": scoring.scoring.model_version,
+            "model_name": scoring.scoring.model_display_name,
         }
     )
 

--- a/recommendation/api/src/pcreco/core/scoring.py
+++ b/recommendation/api/src/pcreco/core/scoring.py
@@ -70,11 +70,10 @@ class Scoring:
 
     def get_recommendation(self) -> List[str]:
         # score the offers
-        scored_offers = self.scoring.get_scored_offers()
         final_recommendations = order_offers_by_score_and_diversify_categories(
-            sorted(scored_offers, key=lambda k: k["score"], reverse=True)[
-                :NUMBER_OF_PRESELECTED_OFFERS
-            ],
+            sorted(
+                self.scoring.get_scored_offers(), key=lambda k: k["score"], reverse=True
+            )[:NUMBER_OF_PRESELECTED_OFFERS],
             SHUFFLE_RECOMMENDATION,
         )
 

--- a/recommendation/api/src/pcreco/core/utils/vertex_ai.py
+++ b/recommendation/api/src/pcreco/core/utils/vertex_ai.py
@@ -34,8 +34,6 @@ def predict_custom_trained_model_sample(
     response = client.predict(
         endpoint=endpoint, instances=instances, parameters=parameters
     )
-    print("response: ", response)
-    print("model_version_id", response.model_version_id)
     response_dict = {
         "predictions": response.predictions,
         "model_version_id": response.model_version_id,

--- a/recommendation/api/src/pcreco/core/utils/vertex_ai.py
+++ b/recommendation/api/src/pcreco/core/utils/vertex_ai.py
@@ -34,6 +34,8 @@ def predict_custom_trained_model_sample(
     response = client.predict(
         endpoint=endpoint, instances=instances, parameters=parameters
     )
+    print("response: ", response)
+    print("model_version_id", response.model_version_id)
     response_dict = {
         "predictions": response.predictions,
         "model_version_id": response.model_version_id,

--- a/recommendation/api/src/pcreco/core/utils/vertex_ai.py
+++ b/recommendation/api/src/pcreco/core/utils/vertex_ai.py
@@ -34,4 +34,9 @@ def predict_custom_trained_model_sample(
     response = client.predict(
         endpoint=endpoint, instances=instances, parameters=parameters
     )
-    return response.predictions
+    response_dict = {
+        "predictions": response.predictions,
+        "model_version_id": response.model_version_id,
+        "model_display_name": response.model_display_name,
+    }
+    return response_dict


### PR DESCRIPTION
- import model metadata from AI vertex client response (cf. [doc](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.PredictResponse) response content)  
- added to \recommendation route for stg testing before adding it to \playlist_recommendation