### PR TITLE
[PC-16608] Create firebase Home events table

### DIFF
--- a/orchestration/dags/dependencies/firebase/import_firebase.py
+++ b/orchestration/dags/dependencies/firebase/import_firebase.py
@@ -115,6 +115,14 @@ import_firebase_tables = {
         "destination_table": "aggregated_daily_offer_consultation_data",
         "depends": ["analytics_firebase_events"],
     },
+    "analytics_firebase_home_events": {
+        "sql": f"{SQL_PATH}/analytics/firebase_home_events.sql",
+        "destination_dataset": "{{ bigquery_analytics_dataset }}",
+        "destination_table": "firebase_home_events",
+        "time_partitioning": {"field": "event_date"},
+        "clustering_fields": {"fields": ["event_type"]},
+        "depends": ["analytics_firebase_events"],
+    },
 }
 
 

--- a/orchestration/dags/dependencies/firebase/sql/analytics/firebase_home_events.sql
+++ b/orchestration/dags/dependencies/firebase/sql/analytics/firebase_home_events.sql
@@ -1,0 +1,167 @@
+WITH mapping_module_name_and_id AS (
+    SELECT
+        *
+    FROM
+        (
+            SELECT
+                relations.parent as module_id,
+                entries.title as module_name,
+                row_number() over (
+                    partition by entries.title
+                    order by
+                        updated_at DESC
+                ) as rnk
+            from
+                `{{ bigquery_analytics_dataset }}.contentful_relationships` relations
+                inner join `{{ bigquery_analytics_dataset }}.contentful_entries` entries on entries.id = relations.child
+            WHERE
+                entries.content_type in (
+                    "displayParameters",
+                    "venuesSearchParameters",
+                    "exclusivityDisplayParameters",
+                    "business"
+                )
+                
+        )
+    where
+        rnk = 1
+),
+firebase_events AS (
+    SELECT
+        coalesce(e.module_id, c_name.module_id) as module_id,
+        e.*
+    EXCEPT
+(module_id, module_name)
+    FROM
+        `{{ bigquery_analytics_dataset }}.firebase_events` e
+        LEFT JOIN mapping_module_name_and_id c_name on c_name.module_name = e.module_name
+    WHERE
+        event_name in (
+            'ConsultOffer',
+            'BusinessBlockClicked',
+            'ExclusivityBlockClicked',
+            'ModuleDisplayedOnHomePage'
+        )
+        AND firebase_screen = "Home"
+        AND event_date >= "2022-07-01" -- no logs before
+),
+firebase_module_events AS (
+    SELECT
+        e.event_date,
+        e.event_timestamp,
+        -- user
+        e.session_id,
+        e.user_id,
+        e.user_pseudo_id,
+        e.platform,
+        --events
+        e.event_name,
+        e.offer_id,
+        -- modules
+        entries.title as module_name,
+        entries.content_type,
+        e.module_id,
+        -- take last seen home_id
+        COALESCE(
+            e.entry_id,
+            LAST_VALUE(e.entry_id IGNORE NULLS) OVER (
+                PARTITION BY user_id,
+                session_id
+                ORDER BY
+                    event_timestamp RANGE BETWEEN UNBOUNDED PRECEDING
+                    AND CURRENT ROW
+            ),
+            LAST_VALUE(e.entry_id IGNORE NULLS) OVER (
+                PARTITION BY module_id
+                ORDER BY
+                    event_date RANGE BETWEEN UNBOUNDED PRECEDING
+                    AND CURRENT ROW
+            )
+        ) AS home_id,
+        -- take last seen module_id
+        COALESCE(
+            module_index,
+            LAST_VALUE(module_index IGNORE NULLS) OVER (
+                PARTITION BY user_id,
+                    session_id,
+                    module_id
+                ORDER BY
+                    event_timestamp RANGE BETWEEN UNBOUNDED PRECEDING
+                    AND CURRENT ROW
+            ),
+            LAST_VALUE(module_index IGNORE NULLS) OVER (
+                PARTITION BY module_id
+                ORDER BY
+                    event_date RANGE BETWEEN UNBOUNDED PRECEDING
+                    AND CURRENT ROW
+            )
+        ) AS module_index
+    FROM
+        firebase_events e
+    LEFT JOIN `{{ bigquery_analytics_dataset }}.contentful_entries` entries on entries.id = e.module_id
+),
+
+-- conversion can be Booking or Favorite
+firebase_conversion_step AS (
+    SELECT 
+        conv.event_date,
+        conv.event_timestamp,
+        conv.session_id,
+        conv.user_id,
+        conv.user_pseudo_id,
+        conv.platform,
+        --events
+        conv.event_name,
+        conv.offer_id,
+
+        event.module_name,
+        event.content_type,
+        event.module_id,
+        event.home_id,
+        event.module_index,
+        -- take last click event
+        ROW_NUMBER() OVER (PARTITION BY conv.session_id, conv.user_id, conv.offer_id, conv.event_name ORDER BY event.event_timestamp DESC) as rank 
+    FROM `{{ bigquery_analytics_dataset }}.firebase_events` conv
+
+    INNER JOIN firebase_module_events event on event.session_id = conv.session_id AND event.offer_id = conv.offer_id AND event.user_id = conv.user_id
+    -- conversion event after click event
+    WHERE conv.event_name IN ('BookingConfirmation', 'HasAddedOfferToFavorites')
+    AND conv.event_timestamp > event.event_timestamp
+    AND conv.event_date >= "2022-07-01" -- no logs before
+),
+
+event_union AS (
+SELECT
+   *
+FROM
+    firebase_module_events
+UNION ALL
+SELECT
+    * EXCEPT(rank)
+FROM firebase_conversion_step
+where rank = 1 -- only one conversion step per event_name
+)
+
+SELECT
+    event_date,
+    event_timestamp,
+    session_id,
+    user_id,
+    user_pseudo_id,
+    platform,
+    event_name,
+    CASE 
+        WHEN event_name = "ModuleDisplayedOnHomePage" THEN "display"
+        WHEN event_name in ("ConsultOffer","BusinessBlockClicked","ExclusivityBlockClicked") THEN "click"
+        WHEN event_name = "HasAddedOfferToFavorites" THEN "favorite"
+        WHEN event_name = "BookingConfirmation" THEN "booking"
+    END as event_type,
+    offer_id,
+    module_name,
+    content_type,
+    module_id,
+    home_id,
+    module_index,
+FROM event_union
+
+

--- a/orchestration/dags/dependencies/firebase/sql/analytics/firebase_home_events.sql
+++ b/orchestration/dags/dependencies/firebase/sql/analytics/firebase_home_events.sql
@@ -21,7 +21,6 @@ WITH mapping_module_name_and_id AS (
                     "exclusivityDisplayParameters",
                     "business"
                 )
-                
         )
     where
         rnk = 1
@@ -31,18 +30,23 @@ firebase_events AS (
         coalesce(e.module_id, c_name.module_id) as module_id,
         e.*
     EXCEPT
-(module_id, module_name)
+        (module_id, module_name)
     FROM
         `{{ bigquery_analytics_dataset }}.firebase_events` e
         LEFT JOIN mapping_module_name_and_id c_name on c_name.module_name = e.module_name
     WHERE
         event_name in (
             'ConsultOffer',
+            "ConsultVenue",
             'BusinessBlockClicked',
             'ExclusivityBlockClicked',
+            "SeeMoreClicked",
             'ModuleDisplayedOnHomePage'
         )
-        AND firebase_screen = "Home"
+        AND (
+            origin = 'home'
+            OR origin IS NULL
+        )
         AND event_date >= "2022-07-01" -- no logs before
 ),
 firebase_module_events AS (
@@ -83,8 +87,8 @@ firebase_module_events AS (
             module_index,
             LAST_VALUE(module_index IGNORE NULLS) OVER (
                 PARTITION BY user_id,
-                    session_id,
-                    module_id
+                session_id,
+                module_id
                 ORDER BY
                     event_timestamp RANGE BETWEEN UNBOUNDED PRECEDING
                     AND CURRENT ROW
@@ -98,12 +102,11 @@ firebase_module_events AS (
         ) AS module_index
     FROM
         firebase_events e
-    LEFT JOIN `{{ bigquery_analytics_dataset }}.contentful_entries` entries on entries.id = e.module_id
+        LEFT JOIN `{{ bigquery_analytics_dataset }}.contentful_entries` entries on entries.id = e.module_id
 ),
-
 -- conversion can be Booking or Favorite
 firebase_conversion_step AS (
-    SELECT 
+    SELECT
         conv.event_date,
         conv.event_timestamp,
         conv.session_id,
@@ -113,55 +116,89 @@ firebase_conversion_step AS (
         --events
         conv.event_name,
         conv.offer_id,
-
         event.module_name,
         event.content_type,
         event.module_id,
         event.home_id,
         event.module_index,
         -- take last click event
-        ROW_NUMBER() OVER (PARTITION BY conv.session_id, conv.user_id, conv.offer_id, conv.event_name ORDER BY event.event_timestamp DESC) as rank 
-    FROM `{{ bigquery_analytics_dataset }}.firebase_events` conv
-
-    INNER JOIN firebase_module_events event on event.session_id = conv.session_id AND event.offer_id = conv.offer_id AND event.user_id = conv.user_id
-    -- conversion event after click event
-    WHERE conv.event_name IN ('BookingConfirmation', 'HasAddedOfferToFavorites')
-    AND conv.event_timestamp > event.event_timestamp
-    AND conv.event_date >= "2022-07-01" -- no logs before
+        ROW_NUMBER() OVER (
+            PARTITION BY conv.session_id,
+            conv.user_id,
+            conv.offer_id,
+            conv.event_name
+            ORDER BY
+                event.event_timestamp DESC
+        ) as rank
+    FROM
+        `{{ bigquery_analytics_dataset }}.firebase_events` conv
+        INNER JOIN firebase_module_events event on event.session_id = conv.session_id
+        AND event.offer_id = conv.offer_id
+        AND event.user_id = conv.user_id -- conversion event after click event
+    WHERE
+        conv.event_name IN (
+            'BookingConfirmation',
+            'HasAddedOfferToFavorites'
+        )
+        AND conv.event_timestamp > event.event_timestamp
+        AND conv.event_date >= "2022-07-01" -- no logs before
 ),
-
 event_union AS (
-SELECT
-   *
-FROM
-    firebase_module_events
-UNION ALL
-SELECT
-    * EXCEPT(rank)
-FROM firebase_conversion_step
-where rank = 1 -- only one conversion step per event_name
+    SELECT
+        *
+    FROM
+        firebase_module_events
+    UNION
+    ALL
+    SELECT
+        *
+    EXCEPT
+        (rank)
+    FROM
+        firebase_conversion_step
+    where
+        rank = 1 -- only one conversion step per event_name
+),
+diversification_booking AS (
+    -- in case we have more than one reservation for the same offer in the same day, take average.
+    SELECT
+        DATE(booking_creation_date) as date,
+        user_id,
+        offer_id,
+        avg(delta_diversification) as delta_diversification 
+    FROM `{{ bigquery_analytics_dataset }}.diversification_booking` 
+    GROUP BY 1,2,3 
 )
-
 SELECT
-    event_date,
-    event_timestamp,
-    session_id,
-    user_id,
-    user_pseudo_id,
-    platform,
-    event_name,
-    CASE 
+    e.event_date,
+    e.event_timestamp,
+    e.session_id,
+    e.user_id,
+    e.user_pseudo_id,
+    e.platform,
+    e.event_name,
+    CASE
         WHEN event_name = "ModuleDisplayedOnHomePage" THEN "display"
-        WHEN event_name in ("ConsultOffer","BusinessBlockClicked","ExclusivityBlockClicked") THEN "click"
+        WHEN event_name in (
+            "ConsultOffer",
+            "ConsultVenue",
+            "BusinessBlockClicked",
+            "ExclusivityBlockClicked"
+        ) THEN "click"
+        WHEN event_name in ("SeeMoreClicked") THEN "see_more_click"
         WHEN event_name = "HasAddedOfferToFavorites" THEN "favorite"
         WHEN event_name = "BookingConfirmation" THEN "booking"
     END as event_type,
-    offer_id,
-    module_name,
-    content_type,
-    module_id,
-    home_id,
-    module_index,
-FROM event_union
-
-
+    e.offer_id,
+    e.module_name,
+    e.content_type,
+    e.module_id,
+    e.home_id,
+    e.module_index,
+    db.delta_diversification,
+FROM
+    event_union e
+LEFT JOIN diversification_booking db 
+    ON db.user_id = e.user_id
+    AND db.offer_id = e.offer_id
+    AND db.date = e.event_date


### PR DESCRIPTION
Firebase table for all events based on the Home Page (view, click, booking, favorites))

Based on [this](https://data-analytics.internal-passculture.app/question/5891-wip-conversion-playlists-v2?date=past1weeks)

## Rules
When we don't have an event, we try to reconciliate it.

No module_id (for recommendation):  
- match based on naming on module_name (cf mapping_module_name_and_id)

No entry_id (home_id) (for all clicks):
- we take take the last seen home page by the user
- or the last seen (not user based) seen match module_id - home_id. (This works as we don't have much modules cross homes)

No module_index (for all clicks): 
- then we look where was the last position of the module when the user saw it
- or the last seen (not user based) position of the module

For bookings & favorites:
- We look if there was any click on this offer *within the same session* on the home page and associate the last module from this clicked offer.

Examples: 
- In case the user: looks at the home page, clicks on offer A, then search offer A, then book it; we count it as it come from Home.


----- 
### Questions
 - Faut-il rajouter le score de diversification directement ? 
