### PR TITLE
[PC-16982] add adage logs

### DIFF
--- a/orchestration/dags/dependencies/logs/sql/analytics/adage_logs.sql
+++ b/orchestration/dags/dependencies/logs/sql/analytics/adage_logs.sql
@@ -7,14 +7,16 @@ SELECT
     END as log_source,
     timestamp,
     jsonPayload.extra.path AS path,
+    jsonPayload.message,
+    jsonPayload.technical_message_id,
     jsonPayload.extra.statuscode AS status_code,
     jsonPayload.extra.method AS method,
     jsonPayload.extra.sourceip AS source_ip,
     jsonPayload.extra.duration AS duration,
     jsonPayload.extra.source as source,
     jsonPayload.extra.userId as user_id,
-    jsonPayload.extra.stockId as stock_id,
-    coalesce(jsonPayload.extra.bookingId, jsonPayload.extra.booking_id) as booking_id,
+    cast(jsonPayload.extra.stockId as int) as stock_id,
+    CAST(coalesce(jsonPayload.extra.bookingId, jsonPayload.extra.booking_id) as int) as booking_id,
 FROM
     `{{ bigquery_raw_dataset }}.stdout`
 WHERE

--- a/orchestration/dags/dependencies/logs/sql/analytics/adage_logs.sql
+++ b/orchestration/dags/dependencies/logs/sql/analytics/adage_logs.sql
@@ -53,3 +53,4 @@ SELECT
 * EXCEPT(session_num, session_start, rnk, same_session, session_sum),
 TO_HEX(MD5(CONCAT(CAST(session_start AS STRING), user_id, session_num))) as session_id,
 FROM generate_session
+WHERE partition_date = DATE("{{ ds }}")

--- a/orchestration/dags/dependencies/logs/sql/analytics/adage_logs.sql
+++ b/orchestration/dags/dependencies/logs/sql/analytics/adage_logs.sql
@@ -1,12 +1,55 @@
+WITH _rows AS (
 SELECT
     DATE(timestamp) as partition_date,
+    CASE 
+        WHEN jsonPayload.extra.path LIKE "%adage-iframe%" THEN 'adage-iframe'
+        ELSE 'adage'
+    END as log_source,
     timestamp,
     jsonPayload.extra.path AS path,
     jsonPayload.extra.statuscode AS status_code,
     jsonPayload.extra.method AS method,
     jsonPayload.extra.sourceip AS source_ip,
-    jsonPayload.extra.duration AS duration
+    jsonPayload.extra.duration AS duration,
+    jsonPayload.extra.source as source,
+    jsonPayload.extra.userId as user_id,
+    jsonPayload.extra.stockId as stock_id,
+    coalesce(jsonPayload.extra.bookingId, jsonPayload.extra.booking_id) as booking_id,
 FROM
     `{{ bigquery_raw_dataset }}.stdout`
 WHERE
-    DATE(timestamp) = "{{ ds }}" AND jsonPayload.extra.path LIKE "%adage-iframe%"
+    DATE(timestamp) >= DATE("{{ add_days(ds, -7) }}")
+    AND DATE(timestamp) <= DATE("{{ ds }}")
+    AND (
+        jsonPayload.extra.path LIKE "%adage-iframe%"
+        OR jsonPayload.extra.analyticsSource = 'adage'
+    )
+),
+
+generate_session AS (
+    SELECT 
+        *,
+        rnk - session_sum  as session_num,
+        MIN(timestamp) OVER (PARTITION BY user_id, rnk - session_sum) as session_start
+    FROM (
+        SELECT
+        *,
+        SUM(same_session) OVER (PARTITION BY user_id  ORDER BY timestamp) as session_sum,
+        ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY timestamp) as rnk
+        FROM (
+            SELECT 
+            *,
+            COALESCE(
+                CAST(
+                    DATE_DIFF(timestamp, LAG(timestamp, 1) OVER (PARTITION BY user_id ORDER BY timestamp), MINUTE) <= 30 AS INT
+                ), 1
+            ) as same_session,
+            FROM _rows
+        ) _inn_count
+    ) _inn_ts
+)
+
+SELECT 
+* EXCEPT(session_num, session_start, rnk, same_session, session_sum),
+TO_HEX(MD5(CONCAT(CAST(session_start AS STRING), user_id, session_num))) as session_id,
+FROM generate_session


### PR DESCRIPTION
- Added rules in order to integrate new adage route
- Added extra fields from Notion documentation
- Added session_id (<= 30min) for same user. Session duration can be max 72h. 

Dev table is in `raw_dev.adage_logs`. 




