### PR TITLE
(Refacto Analytics) switch activation offer filters in clean zone

### DIFF
--- a/orchestration/dags/dependencies/import_analytics/sql/analytics/enriched_booking_data.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/analytics/enriched_booking_data.sql
@@ -105,7 +105,6 @@ FROM
     `{{ bigquery_clean_dataset }}`.applicative_database_booking AS booking
     INNER JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock AS stock ON booking.stock_id = stock.stock_id
     LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON offer.offer_id = stock.offer_id
-    AND offer.offer_subcategoryId NOT IN ('ACTIVATION_THING', 'ACTIVATION_EVENT')
     INNER JOIN `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue ON venue.venue_id = offer.venue_id
     INNER JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offerer AS offerer ON venue.venue_managing_offerer_id = offerer.offerer_id
     INNER JOIN `{{ bigquery_clean_dataset }}`.user_beneficiary AS user ON user.user_id = booking.user_id

--- a/orchestration/dags/dependencies/import_analytics/sql/analytics/enriched_user_data.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/analytics/enriched_user_data.sql
@@ -450,7 +450,6 @@ FROM
     LEFT JOIN date_of_bookings_on_third_product ON user.user_id = date_of_bookings_on_third_product.user_id
     LEFT JOIN number_of_bookings ON user.user_id = number_of_bookings.user_id
     LEFT JOIN number_of_non_cancelled_bookings ON user.user_id = number_of_non_cancelled_bookings.user_id
-    LEFT JOIN users_seniority ON user.user_id = users_seniority.user_id
     LEFT JOIN actual_amount_spent ON user.user_id = actual_amount_spent.user_id
     LEFT JOIN theoretical_amount_spent ON user.user_id = theoretical_amount_spent.user_id
     LEFT JOIN theoretical_amount_spent_in_digital_goods ON user.user_id = theoretical_amount_spent_in_digital_goods.user_id

--- a/orchestration/dags/dependencies/import_analytics/sql/analytics/enriched_venue_data.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/analytics/enriched_venue_data.sql
@@ -25,11 +25,6 @@ total_bookings_per_venue AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock AS stock ON stock.offer_id = offer.offer_id
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_booking AS booking ON stock.stock_id = booking.stock_id
     GROUP BY
@@ -42,11 +37,6 @@ non_cancelled_bookings_per_venue AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock AS stock ON stock.offer_id = offer.offer_id
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_booking AS booking ON stock.stock_id = booking.stock_id
         AND NOT booking.booking_is_cancelled
@@ -60,11 +50,6 @@ used_bookings_per_venue AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock AS stock ON stock.offer_id = offer.offer_id
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_booking AS booking ON stock.stock_id = booking.stock_id
         AND booking.booking_is_used
@@ -78,11 +63,6 @@ first_offer_creation_date AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
     GROUP BY
         venue.venue_id
 ),
@@ -93,11 +73,6 @@ last_offer_creation_date AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
     GROUP BY
         venue.venue_id
 ),
@@ -108,11 +83,6 @@ individual_offers_created_per_venue AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
     GROUP BY
         venue.venue_id
 ),
@@ -152,11 +122,6 @@ theoretic_revenue_per_venue AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock AS stock ON offer.offer_id = stock.offer_id
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_booking AS booking ON booking.stock_id = stock.stock_id
         AND NOT booking.booking_is_cancelled
@@ -175,11 +140,6 @@ real_revenue_per_venue AS (
     FROM
         `{{ bigquery_clean_dataset }}`.applicative_database_venue AS venue
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer AS offer ON venue.venue_id = offer.venue_id
-        AND (
-            offer.booking_email != 'jeux-concours@passculture.app'
-            or offer.booking_email is NULL
-        )
-        AND offer.offer_subcategoryId NOT IN ('ACTIVATION_EVENT', 'ACTIVATION_THING')
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock AS stock ON offer.offer_id = stock.offer_id
         LEFT JOIN `{{ bigquery_clean_dataset }}`.applicative_database_booking AS booking ON booking.stock_id = stock.stock_id
         AND NOT booking.booking_is_cancelled

--- a/orchestration/dags/dependencies/import_analytics/sql/analytics/offer_moderation.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/analytics/offer_moderation.sql
@@ -41,7 +41,6 @@ bookings_days AS (
         `{{ bigquery_clean_dataset }}`.applicative_database_booking booking
         JOIN `{{ bigquery_clean_dataset }}`.applicative_database_stock stock USING(stock_id)
         JOIN `{{ bigquery_clean_dataset }}`.applicative_database_offer offer ON offer.offer_id = stock.offer_id
-            AND offer.offer_subcategoryId NOT IN ('ACTIVATION_THING', 'ACTIVATION_EVENT')
 ),
 
 count_bookings AS (

--- a/orchestration/dags/dependencies/import_analytics/sql/analytics/recommendable_offers_data.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/analytics/recommendable_offers_data.sql
@@ -95,8 +95,6 @@ WITH get_recommendable_offers AS (
         AND offer.offer_is_bookable = TRUE
         AND offerer.offerer_is_active = TRUE
         AND offer.offer_validation = 'APPROVED'
-        AND enriched_item_metadata.subcategory_id NOT IN ('ACTIVATION_THING', 'ACTIVATION_EVENT')
-
 )
 SELECT  * 
 FROM get_recommendable_offers 

--- a/orchestration/dags/dependencies/import_analytics/sql/clean/offer.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/clean/offer.sql
@@ -6,7 +6,7 @@ WITH offer_rank as (
     WHERE offer_subcategoryid NOT IN ('ACTIVATION_THING', 'ACTIVATION_EVENT')
     AND (
         booking_email != 'jeux-concours@passculture.app'
-        booking_email IS NULL
+        OR booking_email IS NULL
     )
 )    
 SELECT * except(row_number)

--- a/orchestration/dags/dependencies/import_analytics/sql/clean/offer.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/clean/offer.sql
@@ -3,6 +3,11 @@ WITH offer_rank as (
         *
         , ROW_NUMBER() OVER (PARTITION BY offer_id ORDER BY offer_date_updated DESC) as row_number
     FROM `{{ bigquery_raw_dataset }}.applicative_database_offer`
+    WHERE offer_subcategoryid NOT IN ('ACTIVATION_THING', 'ACTIVATION_EVENT')
+    AND (
+        booking_email != 'jeux-concours@passculture.app'
+        booking_email IS NULL
+    )
 )    
 SELECT * except(row_number)
 FROM offer_rank

--- a/orchestration/dags/dependencies/import_analytics/sql/clean/user_beneficiary.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/clean/user_beneficiary.sql
@@ -59,7 +59,7 @@ ranked_bookings AS (
 )
 
 SELECT 
-    user_id,
+    user_beneficiary.user_id,
     user_creation_date,
     user_humanized_id,
     user_has_enabled_marketing_email,
@@ -95,6 +95,6 @@ SELECT
     END AS user_activation_date
 FROM user_beneficiary
 LEFT JOIN ranked_bookings 
-    ON user.user_id = ranked_bookings.user_id
+    ON user_beneficiary.user_id = ranked_bookings.user_id
     AND rank_ = 1
 

--- a/orchestration/dags/dependencies/import_recommendation_cloudsql/monitoring_queries/monitor_recommendable_offers_data.sql
+++ b/orchestration/dags/dependencies/import_recommendation_cloudsql/monitoring_queries/monitor_recommendable_offers_data.sql
@@ -10,8 +10,7 @@ non_recommendable_offers as (
     from
         `{{ bigquery_analytics_dataset }}.recommendable_offers_data` offer
     Where
-        offer.subcategory_id in ('ACTIVATION_THING', 'ACTIVATION_EVENT')
-        OR (offer.subcategory_id = 'ACHAT_INSTRUMENT' and REGEXP_CONTAINS(LOWER(offer.name),r'bon d’achat|bons d’achat'))
+        (offer.subcategory_id = 'ACHAT_INSTRUMENT' and REGEXP_CONTAINS(LOWER(offer.name),r'bon d’achat|bons d’achat'))
         OR (offer.subcategory_id = 'MATERIEL_ART_CREATIF'AND REGEXP_CONTAINS(LOWER(offer.name),r'stabilo|surligneurs'))
         OR offer.product_id in (SELECT * FROM `{{ bigquery_raw_dataset }}.forbidden_offers_recommendation`)
 )

--- a/orchestration/tests/data_analytics/config.py
+++ b/orchestration/tests/data_analytics/config.py
@@ -544,6 +544,7 @@ BIGQUERY_SCHEMAS = {
         "user_birth_date": "DATETIME",
         "user_cultural_survey_filled_date": "DATETIME",
         "user_department_code": "STRING",
+        "user_activation_date": "DATETIME",
     },
     "applicative_database_offer_criterion": {
         "offerid": "STRING",

--- a/orchestration/tests/data_analytics/data.py
+++ b/orchestration/tests/data_analytics/data.py
@@ -857,6 +857,7 @@ ENRICHED_USER_DATA_INPUT = {
             "user_birth_date": datetime.now().replace(microsecond=0),
             "user_role": "BENEFICIARY",
             "user_school_type": "Lycée agricole",
+            "user_activation_date": datetime.now().replace(microsecond=0),
         }
     ],
     "user_suspension": [


### PR DESCRIPTION
- ajout du filtre sur les offres ACTIVATION_THING/ACTIVATION_EVENT et jeux-concours dans la table clean offer
- calcul du champs user_activation_date dans la définition de user_beneficiary