### PR TITLE
(PC-24987) parametrisation alertes slack 

### DIFF
--- a/.github/workflows/deploy_composer.yml
+++ b/.github/workflows/deploy_composer.yml
@@ -2,9 +2,9 @@ name: "Deploy Composer"
 
 on:
  push:
-   branches:
-   - master
-   - production
+  branches:
+  - master
+  - production
 
 jobs:
   linter:
@@ -56,7 +56,6 @@ jobs:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
- 
 
   composer-deploy-on-dev:
     if: github.ref == 'refs/heads/production'

--- a/.github/workflows/deploy_composer.yml
+++ b/.github/workflows/deploy_composer.yml
@@ -2,9 +2,9 @@ name: "Deploy Composer"
 
 on:
  push:
-  branches:
-  - master
-  - production
+   # branches:
+   # - master
+   # - production
 
 jobs:
   linter:
@@ -48,21 +48,21 @@ jobs:
      JOB_PATH: ${{ matrix.job }}
      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
   
-  test-orchestration:
-    uses: ./.github/workflows/reusable_test_orchestration.yml
-    with:
-      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
-    secrets:
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
+       #  test-orchestration:
+       #    uses: ./.github/workflows/reusable_test_orchestration.yml
+       #    with:
+       #      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
+       #    secrets:
+       #      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+       #      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+       #      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+       #
 
   composer-deploy-on-dev:
-    if: github.ref == 'refs/heads/production'
+    #  if: github.ref == 'refs/heads/production'
     uses: ./.github/workflows/reusable_deploy_composer.yml
     needs: 
-      - test-orchestration
+      #      - test-orchestration
       - test-jobs
       - linter
     with:
@@ -76,39 +76,39 @@ jobs:
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  composer-deploy-on-stg:
-    if: github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/reusable_deploy_composer.yml
-    needs: 
-      - test-orchestration
-      - test-jobs
-      - linter
-    with:
-      TARGET_ENV:  "staging"
-      COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--00137508-bucket"
-      COMPOSER_ENVIRONMENT_NAME: "data-composer-stg"
-      DATA_GCP_PROJECT: "passculture-data-ehp"
-      NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
-    secrets:
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        #composer-deploy-on-stg:
+        #  if: github.ref == 'refs/heads/master'
+        #  uses: ./.github/workflows/reusable_deploy_composer.yml
+        #  needs: 
+        #    - test-orchestration
+        #    - test-jobs
+        #    - linter
+        #  with:
+        #    TARGET_ENV:  "staging"
+        #    COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--00137508-bucket"
+        #    COMPOSER_ENVIRONMENT_NAME: "data-composer-stg"
+        #    DATA_GCP_PROJECT: "passculture-data-ehp"
+        #    NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
+        #  secrets:
+        #    GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        #    ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+        #    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  composer-deploy-on-prod:
-    if: github.ref == 'refs/heads/production'
-    uses: ./.github/workflows/reusable_deploy_composer.yml
-    needs: 
-      - test-orchestration
-      - test-jobs
-      - linter
-      - composer-deploy-on-dev
-    with:
-      TARGET_ENV:  "production"
-      COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--d5adf2e8-bucket"
-      COMPOSER_ENVIRONMENT_NAME: "data-composer-prod"
-      DATA_GCP_PROJECT: "passculture-data-prod"
-      NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
-    secrets:
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        #composer-deploy-on-prod:
+        #  if: github.ref == 'refs/heads/production'
+        #  uses: ./.github/workflows/reusable_deploy_composer.yml
+        #  needs: 
+        #    - test-orchestration
+        #    - test-jobs
+        #    - linter
+        #    - composer-deploy-on-dev
+        #  with:
+        #    TARGET_ENV:  "production"
+        #    COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--d5adf2e8-bucket"
+        #    COMPOSER_ENVIRONMENT_NAME: "data-composer-prod"
+        #    DATA_GCP_PROJECT: "passculture-data-prod"
+        #    NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
+        #  secrets:
+        #    GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        #    ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+        #    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy_composer.yml
+++ b/.github/workflows/deploy_composer.yml
@@ -7,9 +7,10 @@ on:
   - production
 
 jobs:
-
   linter:
     uses: ./.github/workflows/reusable_linter.yml
+    with:
+     NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
@@ -45,9 +46,12 @@ jobs:
        job: ${{ fromJSON(needs.find-test-jobs.outputs.jobs) }}
    with:
      JOB_PATH: ${{ matrix.job }}
+     NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
   
   test-orchestration:
     uses: ./.github/workflows/reusable_test_orchestration.yml
+    with:
+      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
@@ -66,6 +70,7 @@ jobs:
       COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--a3134989-bucket"
       COMPOSER_ENVIRONMENT_NAME: "data-composer-dev"
       DATA_GCP_PROJECT: "passculture-data-ehp"
+      NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
@@ -83,6 +88,7 @@ jobs:
       COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--00137508-bucket"
       COMPOSER_ENVIRONMENT_NAME: "data-composer-stg"
       DATA_GCP_PROJECT: "passculture-data-ehp"
+      NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
@@ -97,10 +103,11 @@ jobs:
       - linter
       - composer-deploy-on-dev
     with:
-      TARGET_ENV:  "prod"
+      TARGET_ENV:  "production"
       COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--d5adf2e8-bucket"
       COMPOSER_ENVIRONMENT_NAME: "data-composer-prod"
       DATA_GCP_PROJECT: "passculture-data-prod"
+      NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy_composer.yml
+++ b/.github/workflows/deploy_composer.yml
@@ -70,7 +70,6 @@ jobs:
       COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--a3134989-bucket"
       COMPOSER_ENVIRONMENT_NAME: "data-composer-dev"
       DATA_GCP_PROJECT: "passculture-data-ehp"
-      NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
@@ -88,7 +87,6 @@ jobs:
         #    COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--00137508-bucket"
         #    COMPOSER_ENVIRONMENT_NAME: "data-composer-stg"
         #    DATA_GCP_PROJECT: "passculture-data-ehp"
-        #    NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
         #  secrets:
         #    GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         #    ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
@@ -107,7 +105,6 @@ jobs:
         #    COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--d5adf2e8-bucket"
         #    COMPOSER_ENVIRONMENT_NAME: "data-composer-prod"
         #    DATA_GCP_PROJECT: "passculture-data-prod"
-        #    NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
         #  secrets:
         #    GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         #    ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy_composer.yml
+++ b/.github/workflows/deploy_composer.yml
@@ -2,9 +2,9 @@ name: "Deploy Composer"
 
 on:
  push:
-   # branches:
-   # - master
-   # - production
+   branches:
+   - master
+   - production
 
 jobs:
   linter:
@@ -48,21 +48,21 @@ jobs:
      JOB_PATH: ${{ matrix.job }}
      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
   
-       #  test-orchestration:
-       #    uses: ./.github/workflows/reusable_test_orchestration.yml
-       #    with:
-       #      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
-       #    secrets:
-       #      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-       #      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-       #      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-       #
+  test-orchestration:
+    uses: ./.github/workflows/reusable_test_orchestration.yml
+    with:
+      NOTIF_CHANNEL_ID: ${{ vars.DEFAULT_NOTIF_CHANNEL_ID }}
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+ 
 
   composer-deploy-on-dev:
-    #  if: github.ref == 'refs/heads/production'
+    if: github.ref == 'refs/heads/production'
     uses: ./.github/workflows/reusable_deploy_composer.yml
     needs: 
-      #      - test-orchestration
+      - test-orchestration
       - test-jobs
       - linter
     with:
@@ -75,37 +75,37 @@ jobs:
       ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-        #composer-deploy-on-stg:
-        #  if: github.ref == 'refs/heads/master'
-        #  uses: ./.github/workflows/reusable_deploy_composer.yml
-        #  needs: 
-        #    - test-orchestration
-        #    - test-jobs
-        #    - linter
-        #  with:
-        #    TARGET_ENV:  "staging"
-        #    COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--00137508-bucket"
-        #    COMPOSER_ENVIRONMENT_NAME: "data-composer-stg"
-        #    DATA_GCP_PROJECT: "passculture-data-ehp"
-        #  secrets:
-        #    GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        #    ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-        #    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  composer-deploy-on-stg:
+    if: github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/reusable_deploy_composer.yml
+    needs: 
+      - test-orchestration
+      - test-jobs
+      - linter
+    with:
+      TARGET_ENV:  "staging"
+      COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--00137508-bucket"
+      COMPOSER_ENVIRONMENT_NAME: "data-composer-stg"
+      DATA_GCP_PROJECT: "passculture-data-ehp"
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-        #composer-deploy-on-prod:
-        #  if: github.ref == 'refs/heads/production'
-        #  uses: ./.github/workflows/reusable_deploy_composer.yml
-        #  needs: 
-        #    - test-orchestration
-        #    - test-jobs
-        #    - linter
-        #    - composer-deploy-on-dev
-        #  with:
-        #    TARGET_ENV:  "production"
-        #    COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--d5adf2e8-bucket"
-        #    COMPOSER_ENVIRONMENT_NAME: "data-composer-prod"
-        #    DATA_GCP_PROJECT: "passculture-data-prod"
-        #  secrets:
-        #    GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        #    ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-        #    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  composer-deploy-on-prod:
+    if: github.ref == 'refs/heads/production'
+    uses: ./.github/workflows/reusable_deploy_composer.yml
+    needs: 
+      - test-orchestration
+      - test-jobs
+      - linter
+      - composer-deploy-on-dev
+    with:
+      TARGET_ENV:  "production"
+      COMPOSER_DAGS_BUCKET: "europe-west1-data-composer--d5adf2e8-bucket"
+      COMPOSER_ENVIRONMENT_NAME: "data-composer-prod"
+      DATA_GCP_PROJECT: "passculture-data-prod"
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      ARTIFACT_REGISTRY_SERVICE_ACCOUNT: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/reusable_deploy_composer.yml
+++ b/.github/workflows/reusable_deploy_composer.yml
@@ -55,13 +55,13 @@ jobs:
           service_account: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Deploy composer
-        run: |
-              gsutil -m rm -r gs://${{ inputs.COMPOSER_DAGS_BUCKET }}/dags
-              gsutil -m cp -r dags gs://${{ inputs.COMPOSER_DAGS_BUCKET }}
-      - name: Wait for composer to be deployed (10s x 6 times)
-        run: |
-               ./wait_for_dag_deployed.sh ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} ${{ env.GCP_REGION }} airflow_monitoring 6 10 ${{ inputs.DATA_GCP_PROJECT }}
+          #      - name: Deploy composer
+          #        run: |
+          #              gsutil -m rm -r gs://${{ inputs.COMPOSER_DAGS_BUCKET }}/dags
+          #              gsutil -m cp -r dags gs://${{ inputs.COMPOSER_DAGS_BUCKET }}
+          #      - name: Wait for composer to be deployed (10s x 6 times)
+          #        run: |
+          #               ./wait_for_dag_deployed.sh ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} ${{ env.GCP_REGION }} airflow_monitoring 6 10 ${{ inputs.DATA_GCP_PROJECT }}
       - name: Post to a Slack channel
         id: slack
         if: ${{ inputs.NOTIF_CHANNEL_ID != '' && always() }}

--- a/.github/workflows/reusable_deploy_composer.yml
+++ b/.github/workflows/reusable_deploy_composer.yml
@@ -52,13 +52,13 @@ jobs:
           service_account: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
-          #      - name: Deploy composer
-          #        run: |
-          #              gsutil -m rm -r gs://${{ inputs.COMPOSER_DAGS_BUCKET }}/dags
-          #              gsutil -m cp -r dags gs://${{ inputs.COMPOSER_DAGS_BUCKET }}
-          #      - name: Wait for composer to be deployed (10s x 6 times)
-          #        run: |
-          #               ./wait_for_dag_deployed.sh ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} ${{ env.GCP_REGION }} airflow_monitoring 6 10 ${{ inputs.DATA_GCP_PROJECT }}
+      - name: Deploy composer
+        run: |
+              gsutil -m rm -r gs://${{ inputs.COMPOSER_DAGS_BUCKET }}/dags
+              gsutil -m cp -r dags gs://${{ inputs.COMPOSER_DAGS_BUCKET }}
+      - name: Wait for composer to be deployed (10s x 6 times)
+        run: |
+               ./wait_for_dag_deployed.sh ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} ${{ env.GCP_REGION }} airflow_monitoring 6 10 ${{ inputs.DATA_GCP_PROJECT }}
       - name: Post to a Slack channel
         id: slack
         if: ${{ always() }}

--- a/.github/workflows/reusable_deploy_composer.yml
+++ b/.github/workflows/reusable_deploy_composer.yml
@@ -17,9 +17,6 @@ on:
       TARGET_ENV:
         type: string
         required: true
-      NOTIF_CHANNEL_ID:
-        type: string
-        required: false # Si pas fourni, alors pas de notif
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -64,10 +61,10 @@ jobs:
           #               ./wait_for_dag_deployed.sh ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} ${{ env.GCP_REGION }} airflow_monitoring 6 10 ${{ inputs.DATA_GCP_PROJECT }}
       - name: Post to a Slack channel
         id: slack
-        if: ${{ inputs.NOTIF_CHANNEL_ID != '' && always() }}
+        if: ${{ always() }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ inputs.NOTIF_CHANNEL_ID }}
+          channel-id: ${{ vars.NOTIF_CHANNEL_ID }}
           payload: |
             {
                     "attachments": [

--- a/.github/workflows/reusable_deploy_composer.yml
+++ b/.github/workflows/reusable_deploy_composer.yml
@@ -17,6 +17,9 @@ on:
       TARGET_ENV:
         type: string
         required: true
+      NOTIF_CHANNEL_ID:
+        type: string
+        required: false # Si pas fourni, alors pas de notif
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -35,6 +38,7 @@ jobs:
       contents: write
     container: google/cloud-sdk:448.0.0
     runs-on: [self-hosted, linux, x64]
+    environment: ${{ inputs.TARGET_ENV }}
     defaults:
      run: 
        working-directory: "./orchestration/"
@@ -60,10 +64,10 @@ jobs:
                ./wait_for_dag_deployed.sh ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} ${{ env.GCP_REGION }} airflow_monitoring 6 10 ${{ inputs.DATA_GCP_PROJECT }}
       - name: Post to a Slack channel
         id: slack
-        if: ${{ always() }}
+        if: ${{ inputs.NOTIF_CHANNEL_ID != '' && always() }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: "C01GVAXM02W" # alertes-data
+          channel-id: ${{ inputs.NOTIF_CHANNEL_ID }}
           payload: |
             {
                     "attachments": [

--- a/.github/workflows/reusable_job_test.yml
+++ b/.github/workflows/reusable_job_test.yml
@@ -8,6 +8,9 @@ on:
       JOB_PATH:
         type: string
         required: true
+      NOTIF_CHANNEL_ID:
+        type: string
+        required: false # Si pas fourni, alors pas de notif
     secrets:
       SLACK_BOT_TOKEN:
         required: true
@@ -38,12 +41,12 @@ jobs:
           pytest tests
       - name: Post to a Slack channel
         id: slack
-        if: ${{ failure() }}
+        if: ${{ inputs.NOTIF_CHANNEL_ID != '' && failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          channel-id: "C01GVAXM02W" # alertes-data 
+          channel-id: ${{ inputs.NOTIF_CHANNEL_ID }}
           payload: |
             {
                     "attachments": [

--- a/.github/workflows/reusable_linter.yml
+++ b/.github/workflows/reusable_linter.yml
@@ -2,6 +2,10 @@ name: "Linter job"
 
 on:
   workflow_call:
+    inputs:
+      NOTIF_CHANNEL_ID:
+        type: string
+        required: false # Si pas fourni, alors pas de notif
     secrets:
       SLACK_BOT_TOKEN:
         required: true
@@ -22,12 +26,12 @@ jobs:
         run: black --check --verbose .
       - name: Post to a Slack channel
         id: slack
-        if: ${{ failure() }}
+        if: ${{ inputs.NOTIF_CHANNEL_ID != '' && failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          channel-id: "C01GVAXM02W" # alertes-data 
+          channel-id: ${{ inputs.NOTIF_CHANNEL_ID }}
           payload: |
             {
                     "attachments": [

--- a/.github/workflows/reusable_test_orchestration.yml
+++ b/.github/workflows/reusable_test_orchestration.yml
@@ -2,6 +2,10 @@ name: "Test Orchestration"
 
 on:
   workflow_call:
+    inputs:
+      NOTIF_CHANNEL_ID:
+        type: string
+        required: false # Si pas fourni, alors pas de notif
     secrets:
        GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -56,10 +60,10 @@ jobs:
           pytest tests
       - name: Post to a Slack channel
         id: slack
-        if: ${{ failure() }}
+        if: ${{ inputs.NOTIF_CHANNEL_ID != '' && failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: "C01GVAXM02W" # alertes-data
+          channel-id: ${{ inputs.NOTIF_CHANNEL_ID }}
           payload: |
             {
                     "attachments": [


### PR DESCRIPTION
<!-- (go the the `Preview` tab and to preview rendered PR)

To tick boxe replace [ ] with [x]

 -->

## Describe your changes

J'ai utilisé les environnements afin de rediriger les alertes vers le bon channel en fonction de la ou on déploie.

Pour les workflows j'ai préféré ne pas les lier á un environnement et j'ai donc créé une nouvelle variable contenant le channel_id a utiliser dans ces cas là.

Dans le base workflow même une erreur ne déclenche pas d'alerte : 
https://github.com/pass-culture/data-gcp/actions/runs/6468605130/job/17560967578

En revanche une erreur dans le workflow deploy composer en déclenchera une : 
https://github.com/pass-culture/data-gcp/actions/runs/6468604761/job/17560973496

Et exemple de workflow qui notifie lors d'un déploiement réussi : https://github.com/pass-culture/data-gcp/actions/runs/6469540215/job/17564031280

## Jira ticket number and/or notion link

https://passculture.atlassian.net/browse/PC-24987

