### PR TITLE
Fix first_week in weekly_user_data

### DIFF
--- a/orchestration/dags/dependencies/import_analytics/sql/analytics/aggregated_weekly_user_data.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/analytics/aggregated_weekly_user_data.sql
@@ -21,8 +21,8 @@ WITH
   INNER JOIN
     weeks
   ON
-    weeks.week BETWEEN DATE(enriched_deposit_data.deposit_creation_date)
-    AND DATE(enriched_deposit_data.deposit_expiration_date) -- Toutes les semaines de vie du crédit
+    weeks.week BETWEEN DATE_TRUNC(DATE(enriched_deposit_data.deposit_creation_date),WEEK(MONDAY))
+    AND DATE_TRUNC(DATE(enriched_deposit_data.deposit_expiration_date),WEEK(MONDAY)) -- Toutes les semaines de vie du crédit
     AND deposit_creation_date > '2021-05-20' -- Les utilisateurs post sortie de l'app mobile
   INNER JOIN
     `{{ bigquery_analytics_dataset }}.firebase_aggregated_users` fau


### PR DESCRIPTION
Only users credited on Monday had a weeks_since_deposit_created = 0 due to date filter

# DE PR

## Describe your changes

Please include a summary of the changes:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Tag a reviewer if necessacy  @github/username 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [x] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [ ] New table (non-breaking change)
- [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] I have updated the dag
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [x] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket
