### PR TITLE
(fix)(firebase) Fix daily dag to not depend on contentful dag

### DIFF
--- a/orchestration/dags/jobs/import/import_firebase.py
+++ b/orchestration/dags/jobs/import/import_firebase.py
@@ -63,6 +63,8 @@ for type, params in dags.items():
     table_jobs = {}
     import_tables_temp = copy.deepcopy(import_tables)
     for table, job_params in import_tables_temp.items():
+        if type == "daily" and import_tables_temp[table].get("dag_depends") is not None:
+            del import_tables_temp[table]["dag_depends"]
         # force this to include custom yyyymmdd
         if job_params.get("partition_prefix", None) is not None:
             job_params[


### PR DESCRIPTION
# Hotfix

## Describe your changes

Please include a summary of the changes:

Cette PR retire la dépendance au DAG contentful dans la version daily du dag firebase.

Tag a reviewer if necessacy  @cdelabre 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [x] I have updated the dag
- [x] I will create a review on slack. The review task should be short (<10min).