### PR TITLE
[PC-25254](analytics) Add last year comparison in propilote kpis

### DIFF
--- a/orchestration/dags/dependencies/propilote/export_propilote.py
+++ b/orchestration/dags/dependencies/propilote/export_propilote.py
@@ -286,7 +286,7 @@ tmp_tables_detailed = {
         "destination_table": "{{ yyyymmdd(ds) }}_propilote_tmp_taux_participation_eac_ecoles_region",
         "params": {
             "group_type": "REG",
-            "group_type_name": "institution_region_name",
+            "group_type_name": "region_name",
         },
     },
     "propilote_taux_participation_eac_ecoles_departement": {
@@ -295,7 +295,7 @@ tmp_tables_detailed = {
         "destination_table": "{{ yyyymmdd(ds) }}_propilote_tmp_taux_participation_eac_ecoles_departement",
         "params": {
             "group_type": "DEPT",
-            "group_type_name": "institution_departement_code",
+            "group_type_name": "department_code",
         },
     },
     "propilote_taux_participation_eac_ecoles_academie": {
@@ -304,7 +304,7 @@ tmp_tables_detailed = {
         "destination_table": "{{ yyyymmdd(ds) }}_propilote_tmp_taux_participation_eac_ecoles_academie",
         "params": {
             "group_type": "ACAD",
-            "group_type_name": "institution_academie",
+            "group_type_name": "academy_name",
         },
     },
     "propilote_taux_participation_eac_ecoles_all": {

--- a/orchestration/dags/dependencies/propilote/sql/analytics/pilote_export.sql
+++ b/orchestration/dags/dependencies/propilote/sql/analytics/pilote_export.sql
@@ -25,11 +25,14 @@ WITH temp1 AS
               WHEN
                    INDICATOR = "taux_participation_eac_ecoles" THEN "IND-046"
           END AS identifiant_indic,
-          numerator,
-          denominator
+          sum(numerator) as numerator,
+          sum(denominator) as denominator
    FROM `{{ bigquery_analytics_dataset }}`.propilote_kpis
    LEFT JOIN `{{ bigquery_analytics_dataset }}`.region_department ON propilote_kpis.dimension_value = region_department.num_dep
-   WHERE dimension_name != 'ACAD' ),
+   WHERE dimension_name != 'ACAD' AND is_current_year
+   GROUP BY 1,2,3,4,5,6
+   
+   ),
      temp2 AS
   (SELECT identifiant_indic,
           CASE

--- a/orchestration/dags/dependencies/propilote/sql/analytics/propilote_kpis.sql
+++ b/orchestration/dags/dependencies/propilote/sql/analytics/propilote_kpis.sql
@@ -2,6 +2,7 @@
     {% for granularity in  ['region', 'departement', 'academie','all'] %}
         SELECT
             cast(month as date) as month
+            , "TRUE" AS is_current_year
             , cast(dimension_name as STRING) as dimension_name			
             , cast(dimension_value as STRING) as dimension_value
             , cast(user_type as STRING) as user_type
@@ -13,6 +14,23 @@
     {% if not loop.last %}
         UNION ALL 
     {% endif %}
+        SELECT
+            -- Changer ici prendre month + 12 month
+            cast(month as date) as month
+            , "FALSE" AS is_current_year
+            , cast(dimension_name as STRING) as dimension_name			
+            , cast(dimension_value as STRING) as dimension_value
+            , cast(user_type as STRING) as user_type
+            , cast(indicator as STRING) as indicator
+            , cast(numerator as INTEGER) as numerator
+            , cast(denominator as INTEGER) as denominator
+        FROM
+        -- Changer ici prendre yyyy - 1 
+            `{{ bigquery_tmp_dataset }}.{{ yyyymmdd(ds) }}_{{ kpi_details.table_name }}_{{ granularity }}`
+    {% if not loop.last %}
+        UNION ALL 
+    {% endif %}
+    
     {% endfor %}
 
 {% if not loop.last %}

--- a/orchestration/dags/dependencies/propilote/sql/analytics/propilote_kpis.sql
+++ b/orchestration/dags/dependencies/propilote/sql/analytics/propilote_kpis.sql
@@ -2,7 +2,7 @@
     {% for granularity in  ['region', 'departement', 'academie','all'] %}
         SELECT
             cast(month as date) as month
-            , "TRUE" AS is_current_year
+            , True AS is_current_year
             , cast(dimension_name as STRING) as dimension_name			
             , cast(dimension_value as STRING) as dimension_value
             , cast(user_type as STRING) as user_type
@@ -11,13 +11,13 @@
             , cast(denominator as INTEGER) as denominator
         FROM
             `{{ bigquery_tmp_dataset }}.{{ yyyymmdd(ds) }}_{{ kpi_details.table_name }}_{{ granularity }}`
-    {% if not loop.last %}
+    
         UNION ALL 
-    {% endif %}
+
         SELECT
-            -- Changer ici prendre month + 12 month
-            cast(month as date) as month
-            , "FALSE" AS is_current_year
+            
+            date(DATE_TRUNC(DATE_ADD(cast(month as date), interval 1 year), MONTH)) as month
+            , False AS is_current_year
             , cast(dimension_name as STRING) as dimension_name			
             , cast(dimension_value as STRING) as dimension_value
             , cast(user_type as STRING) as user_type
@@ -25,8 +25,8 @@
             , cast(numerator as INTEGER) as numerator
             , cast(denominator as INTEGER) as denominator
         FROM
-        -- Changer ici prendre yyyy - 1 
             `{{ bigquery_tmp_dataset }}.{{ yyyymmdd(ds) }}_{{ kpi_details.table_name }}_{{ granularity }}`
+        WHERE DATE_TRUNC(DATE_SUB(CURRENT_DATE, interval 1 year), MONTH) = DATE_TRUNC(cast(month as date), MONTH)
     {% if not loop.last %}
         UNION ALL 
     {% endif %}

--- a/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_ecoles/propilote_tmp_participation_eac_ecoles.sql
+++ b/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_ecoles/propilote_tmp_participation_eac_ecoles.sql
@@ -1,15 +1,20 @@
-WITH last_day AS (
+WITH last_year_beginning_date as (
+SELECT 
+    educational_year_beginning_date as last_year_start_date
+FROM `{{ bigquery_analytics_dataset }}.applicative_database_educational_year` 
+WHERE educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 year) AND educational_year_expiration_date > DATE_SUB(current_date(), interval 1 year)
+)
+
+, last_day AS (
 SELECT 
     DATE_TRUNC(date,MONTH) AS date,
-    MAX(date) AS last_date 
+    MAX(date) AS last_date,
+    MAX(adage_id) AS last_adage_id
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_student`
 WHERE 
-    -- On prend l'année scolaire en cours 
-    (educational_year_beginning_date <= current_date() AND educational_year_expiration_date > current_date()) 
-    OR 
-    -- Et l'année scolaire précédente pour la comparaison 
-    (educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 year) AND educational_year_expiration_date > DATE_SUB(current_date(), interval 1 year)) 
-GROUP BY 1
+    date <= current_date 
+AND 
+    date > (select last_year_start_date from last_year_beginning_date)GROUP BY 1
 )
 
 SELECT
@@ -26,11 +31,9 @@ SELECT
     , SUM(total_institutions) AS denominator -- total_institutions
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_institution` as involved
 -- take only last day for each month.
-JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date 
+JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date AND last_day.last_adage_id = involved.adage_id
 LEFT JOIN `{{ bigquery_analytics_dataset }}.region_department` as rd
     ON involved.department_code = rd.num_dep
--- on selectionne uniquement l'année scolaire qui correspond à la date de calcul
-JOIN `{{ bigquery_analytics_dataset }}.applicative_database_educational_year` as ey ON ey.scholar_year = involved.scholar_year AND last_day.last_date >= ey.educational_year_beginning_date AND last_day.last_date < ey.educational_year_expiration_date
 WHERE
 {% if params.group_type == 'NAT' %}
     department_code = '-1'

--- a/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_ecoles/propilote_tmp_participation_eac_ecoles.sql
+++ b/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_ecoles/propilote_tmp_participation_eac_ecoles.sql
@@ -1,55 +1,40 @@
-WITH dates AS (
-    select 
-        month as month
-    from unnest(generate_date_array('2023-08-01', current_date(), interval 1 month)) month
-),
-
-institutions AS (
-    SELECT 
-        dates.month
-        , "{{ params.group_type }}" as dimension_name
-        , {% if params.group_type == 'NAT' %}
-            'NAT'
-        {% else %}
-            {{ params.group_type_name }}
-        {% endif %} as dimension_value
-        , COUNT(DISTINCT institution_id) AS total_institutions
-    FROM dates
-    LEFT JOIN `{{ bigquery_analytics_dataset }}.enriched_institution_data` institution
-        ON dates.month >= DATE_TRUNC(institution.first_deposit_creation_date, MONTH)
-    GROUP BY 1, 2, 3
-), 
-
-active_institutions AS (
-    SELECT 
-        dates.month
-        , "{{ params.group_type }}" as dimension_name
-        , {% if params.group_type == 'NAT' %}
-            'NAT'
-        {% else %}
-            {{ params.group_type_name }}
-        {% endif %} as dimension_value
-        , COUNT(DISTINCT educational_institution_id) AS total_active_institutions
-    FROM dates
-    JOIN `{{ bigquery_analytics_dataset }}.enriched_collective_booking_data` as collective_booking
-        ON dates.month >= DATE_TRUNC(collective_booking.collective_booking_creation_date, MONTH)
-        AND collective_booking_status IN ('USED','REIMBURSED','CONFIRMED')
-        AND scholar_year = "2023-2024" 
-    JOIN `{{ bigquery_analytics_dataset }}.enriched_institution_data` as institution
-        ON collective_booking.educational_institution_id = institution.institution_id
-    GROUP BY 1, 2, 3
-    )
-
+WITH last_day AS (
 SELECT 
-    institutions.month 
-    , institutions.dimension_name
-    , institutions.dimension_value
-    , null as user_type 
-    , "taux_participation_eac_ecoles" as indicator
-    , total_active_institutions as numerator
-    , total_institutions as denominator
+    DATE_TRUNC(date,MONTH) AS date,
+    MAX(date) AS last_date 
+FROM `{{ bigquery_analytics_dataset }}.adage_involved_student`
+WHERE 
+    -- On prend l'année scolaire en cours 
+    (educational_year_beginning_date <= current_date() AND educational_year_expiration_date > current_date()) 
+    OR 
+    -- Et l'année scolaire précédente pour la comparaison 
+    (educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 year) AND educational_year_expiration_date > DATE_SUB(current_date(), interval 1 year)) 
+GROUP BY 1
+)
 
-FROM institutions
-LEFT JOIN active_institutions 
-    ON institutions.month = active_institutions.month 
-    AND institutions.dimension_value = active_institutions.dimension_value
+SELECT
+    DATE_TRUNC(involved.date, MONTH) AS month
+    , "{{ params.group_type }}" as dimension_name
+    , {% if params.group_type == 'NAT' %}
+        'NAT'
+    {% else %}
+        {{ params.group_type_name }}
+    {% endif %} as dimension_value
+    , null as user_type -- nous n'avons pas le détail par age dans la table adage_involved_institution
+    , "taux_participation_eac_jeunes" as indicator
+    , SUM(institutions) AS numerator -- active_institutions
+    , SUM(total_institutions) AS denominator -- total_institutions
+FROM `{{ bigquery_analytics_dataset }}.adage_involved_institution` as involved
+-- take only last day for each month.
+JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date 
+LEFT JOIN `{{ bigquery_analytics_dataset }}.region_department` as rd
+    ON involved.department_code = rd.num_dep
+-- on selectionne uniquement l'année scolaire qui correspond à la date de calcul
+JOIN `{{ bigquery_analytics_dataset }}.applicative_database_educational_year` as ey ON ey.scholar_year = involved.scholar_year AND last_day.last_date >= ey.educational_year_beginning_date AND last_day.last_date < ey.educational_year_expiration_date
+WHERE
+{% if params.group_type == 'NAT' %}
+    department_code = '-1'
+{% else %}
+    NOT department_code = '-1'
+{% endif %}
+GROUP BY 1, 2, 3, 4, 5

--- a/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_jeunes/propilote_tmp_participation_eac_jeunes.sql
+++ b/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_jeunes/propilote_tmp_participation_eac_jeunes.sql
@@ -3,7 +3,12 @@ SELECT
     DATE_TRUNC(date,MONTH) AS date,
     MAX(date) AS last_date 
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_student`
-WHERE date >= '2023-08-01'
+WHERE 
+    -- On prend l'année scolaire en cours 
+    (educational_year_beginning_date <= current_date() AND educational_year_expiration_date > current_date()) 
+    OR 
+    -- Et l'année scolaire précédente pour la comparaison 
+    (educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 year) AND educational_year_expiration_date > DATE_SUB(current_date(), interval 1 year)) 
 GROUP BY 1
 )
 
@@ -15,7 +20,7 @@ SELECT
     {% else %}
         {{ params.group_type_name }}
     {% endif %} as dimension_value
-    , null as user_type -- nous n'avons pas le détail par age dans la table adage_involved_students
+    , level_code as user_type -- On utilise le user_type pour distinguer le taux de participation EAC par niveau d'éducation
     , "taux_participation_eac_jeunes" as indicator
     , SUM(involved_students) AS numerator -- students_involved_in_eac_offer
     , SUM(total_involved_students) AS denominator -- students_eligible
@@ -24,11 +29,12 @@ FROM `{{ bigquery_analytics_dataset }}.adage_involved_student` as involved
 JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date 
 LEFT JOIN `{{ bigquery_analytics_dataset }}.region_department` as rd
     ON involved.department_code = rd.num_dep
+-- on selectionne uniquement l'année scolaire qui correspond à la date de calcul
+JOIN `{{ bigquery_analytics_dataset }}.applicative_database_educational_year` as ey ON ey.scholar_year = involved.scholar_year AND last_day.last_date >= ey.educational_year_beginning_date AND last_day.last_date < ey.educational_year_expiration_date
 WHERE
 {% if params.group_type == 'NAT' %}
     department_code = '-1'
 {% else %}
     NOT department_code = '-1'
 {% endif %}
-AND involved.scholar_year = "2023-2024" 
 GROUP BY 1, 2, 3, 4, 5

--- a/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_jeunes/propilote_tmp_participation_eac_jeunes.sql
+++ b/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_jeunes/propilote_tmp_participation_eac_jeunes.sql
@@ -1,14 +1,20 @@
-WITH last_day AS (
+WITH last_year_beginning_date as (
+SELECT 
+    educational_year_beginning_date as last_year_start_date
+FROM `{{ bigquery_analytics_dataset }}.applicative_database_educational_year` 
+WHERE educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 year) AND educational_year_expiration_date > DATE_SUB(current_date(), interval 1 year)
+)
+
+, last_day AS (
 SELECT 
     DATE_TRUNC(date,MONTH) AS date,
-    MAX(date) AS last_date 
-FROM `{{ bigquery_analytics_dataset }}.adage_involved_student`
+    MAX(date) AS last_date,
+    MAX(adage_id) AS last_adage_id
+FROM `{{ bigquery_analytics_dataset }}.adage_involved_institution`
 WHERE 
-    -- On prend l'année scolaire en cours 
-    (educational_year_beginning_date <= current_date() AND educational_year_expiration_date > current_date()) 
-    OR 
-    -- Et l'année scolaire précédente pour la comparaison 
-    (educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 year) AND educational_year_expiration_date > DATE_SUB(current_date(), interval 1 year)) 
+    date <= current_date 
+AND 
+    date > (select last_year_start_date from last_year_beginning_date)
 GROUP BY 1
 )
 
@@ -26,11 +32,10 @@ SELECT
     , SUM(total_involved_students) AS denominator -- students_eligible
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_student` as involved
 -- take only last day for each month.
-JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date 
+JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date AND last_day.last_adage_id = involved.adage_id
 LEFT JOIN `{{ bigquery_analytics_dataset }}.region_department` as rd
     ON involved.department_code = rd.num_dep
 -- on selectionne uniquement l'année scolaire qui correspond à la date de calcul
-JOIN `{{ bigquery_analytics_dataset }}.applicative_database_educational_year` as ey ON ey.scholar_year = involved.scholar_year AND last_day.last_date >= ey.educational_year_beginning_date AND last_day.last_date < ey.educational_year_expiration_date
 WHERE
 {% if params.group_type == 'NAT' %}
     department_code = '-1'


### PR DESCRIPTION
# DE PR

## Describe your changes

Please include a summary of the changes:

This PR add a dimension is_current_year to the table propilote_kpis to easily compare scholar years. 
It changes the sql kpis to always compute from today to the first day of the last scholar year.
It changes the kpi taux_participation_eac_ecoles, originally computed from enriched_collective_booking_data, and now from adage_involved_institution. 

Tag a reviewer if necessacy  @github/username 

## Jira ticket number and/or notion link

JIRA-PC-25254-add-last-year-comparison-in-propilote-kpis

### Type of change
- [] Fix (non-breaking change which corrects expected behavior)
- [] New fields (non-breaking change)
- [] New table (non-breaking change)
- [x] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] I have updated the dag
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket
