### PR TITLE
(fix)(api_ref) import subcategory pro_label instead of category pro_…

### DIFF
--- a/jobs/etl_jobs/internal/import_api_referentials/main.py
+++ b/jobs/etl_jobs/internal/import_api_referentials/main.py
@@ -46,7 +46,7 @@ def get_subcategories(gcp_project_id, env_short_name):
         _exports = {
             "id": subcats.id,
             "category_id": subcats.category.id,
-            "pro_label": subcats.category.pro_label,
+            "pro_label": subcats.pro_label,
             "app_label": subcats.app_label,
             "search_group_name": subcats.search_group_name,
             "homepage_label_name": subcats.homepage_label_name,


### PR DESCRIPTION
…label

# Hotfix

## Describe your changes

Please include a summary of the changes:

Dans la table analytics_env.subcategories, fix pour importer le pro_label de la sous-catégorie et non de la catégorie.

Tag a reviewer if necessacy  @mathilde-vey 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [x] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [x] I will create a review on slack. The review task should be short (<10min).