### PR TITLE
(fix) fix acces gcp secrets function following composer upgrade

### DIFF
--- a/orchestration/airflow/orchestration-requirements.txt
+++ b/orchestration/airflow/orchestration-requirements.txt
@@ -1,5 +1,5 @@
---constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.10.txt"
-apache-airflow[gcp]==2.4.3
+--constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt"
+apache-airflow[gcp]==2.6.3
 sshtunnel>=0.4.0
 # tests
 pytest>=6.1

--- a/orchestration/dags/common/access_gcp_secrets.py
+++ b/orchestration/dags/common/access_gcp_secrets.py
@@ -7,7 +7,7 @@ def access_secret_data(project_id, secret_id, default=None):
     try:
         client = secretmanager.SecretManagerServiceClient()
         name = f"projects/{project_id}/secrets/{secret_id}/versions/latest"
-        response = client.access_secret_version(name)
+        response = client.access_secret_version(request={"name": name})
         return response.payload.data.decode("UTF-8")
     except (DefaultCredentialsError, PermissionDenied, NotFound) as e:
         return default


### PR DESCRIPTION
# Hotfix

## Describe your changes

!! TO merge when composer-stg is upgrade to 2.6.3

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [ ] I will create a review on slack. The review task should be short (<10min).