### PR TITLE
(applicative) remove analytics import of a batch of tables 

### DIFF
--- a/orchestration/dags/dependencies/import_analytics/import_analytics.py
+++ b/orchestration/dags/dependencies/import_analytics/import_analytics.py
@@ -5,38 +5,25 @@ ANALYTICS_SQL_PATH = f"dependencies/import_analytics/sql/analytics"
 
 def define_import_tables():
     return [
-        "bank_information",
         "beneficiary_fraud_check",
         "booking",
-        "cashflow",
         "collective_offer",
         "collective_offer_domain",
         "criterion",
         "deposit",
-        "educational_deposit",
         "educational_domain",
-        "educational_institution",
         "educational_year",
         "favorite",
         "offer",
         "offer_criterion",
         "offerer",
-        "payment",
-        "payment_status",
         "pricing",
-        "pricing_line",
         "stock",
         "user",
         "user_offerer",
         "venue",
         "venue_provider",
         # add temporarly reimbursement tables
-        "cashflow_batch",
-        "cashflow_log",
-        "cashflow_pricing",
-        "invoice",
-        "invoice_cashflow",
-        "invoice_line",
         "venue_reimbursement_point_link",
     ]
 


### PR DESCRIPTION
[DE]
Cette PR supprime l'import en analytics des tables applicatives qui ont généré moins de 10 consultations de cartes sur Metabase depuis le 1er février dernier

Requête : 
```(sql)
select 
  table_name
  , count(distinct case when date_trunc(last_execution_date, month) >= '2024-02-01' then  card_id else null end) 
  nb_cards_consulted_last_month
  , count(distinct case when date_trunc(last_execution_date, month) < '2024-02-01' then  card_id else null end) nb_cards_not_consulted_last_month
from `passculture-data-prod.sandbox_prod.dependencies_metabase_applicative` m
left join `passculture-data-prod.analytics_prod.metabase_activity` a
using (card_id)
  table_name
  , count(distinct case when date_trunc(last_execution_date, month) >= '2024-02-01' then  card_id else null end) 
  nb_cards_consulted_last_month
  , count(distinct case when date_trunc(last_execution_date, month) < '2024-02-01' then  card_id else null end) nb_cards_not_consulted_last_month
from `passculture-data-prod.sandbox_prod.dependencies_metabase_applicative` m
left join `passculture-data-prod.analytics_prod.metabase_activity` a
using (card_id)
where lower(m.card_name) not like 'archive%'
and table_name like 'applicative_database_%'
GROUP BY table_name
having nb_cards_consulted_last_month <= 10
order by nb_cards_consulted_last_month desc 
where lower(m.card_name) not like 'archive%'
and table_name like 'applicative_database_%'
GROUP BY table_name
having nb_cards_consulted_last_month <= 10
order by nb_cards_consulted_last_month desc 
```