### PR TITLE
Update booking table name

### DIFF
--- a/orchestration/dags/dependencies/import_analytics/sql/clean/applicative_database/booking_history.sql
+++ b/orchestration/dags/dependencies/import_analytics/sql/clean/applicative_database/booking_history.sql
@@ -13,4 +13,4 @@ SELECT
     booking_cancellation_reason,
     booking_reimbursement_date,
     DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY) as partition_date
-FROM `{{ bigquery_clean_dataset }}`.`booking`
+FROM `{{ bigquery_clean_dataset }}`.`applicative_database_booking`

--- a/orchestration/dags/dependencies/training_data/sql/training_data_bookings.sql
+++ b/orchestration/dags/dependencies/training_data/sql/training_data_bookings.sql
@@ -15,7 +15,7 @@ SELECT
     enroffer.venue_id,
     enroffer.venue_name,
 from
-    `{{ bigquery_clean_dataset }}`.`booking` booking
+    `{{ bigquery_clean_dataset }}`.`applicative_database_booking` booking
     inner join `{{ bigquery_clean_dataset }}`.`applicative_database_stock` stock on booking.stock_id = stock.stock_id
     inner join `{{ bigquery_clean_dataset }}`.`applicative_database_offer` offer on stock.offer_id = offer.offer_id
     inner join `{{ bigquery_analytics_dataset }}`.`subcategories` subcategories on offer.offer_subcategoryId = subcategories.id


### PR DESCRIPTION
# Hotfix

## Describe your changes

Update table name in `booking_history` and `training_data_bookings` model (because the alias of `clean_prod.applicative_database_booking` has been removed).

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [ ] I will create a review on slack. The review task should be short (<10min).