### PR TITLE
(dbt) Override marketing attribution channel

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/intermediate/firebase/native/int_firebase__native_attribution.sql
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/firebase/native/int_firebase__native_attribution.sql
@@ -7,9 +7,7 @@ WITH campaigns AS (
     MIN(event_timestamp) AS campaign_begins_at,
     TIMESTAMP_ADD(MIN(event_timestamp), INTERVAL 1 DAY) AS original_campaign_ends_at
 FROM {{ ref("int_firebase__native_event_flattened") }}
-  WHERE
-    traffic_campaign IS NOT NULL AND traffic_source IS NOT NULL
-    AND event_date BETWEEN '2023-12-20' AND '2024-04-04'
+  WHERE traffic_campaign IS NOT NULL AND traffic_source IS NOT NULL
   GROUP BY
     user_pseudo_id,
     traffic_campaign,

--- a/orchestration/dags/data_gcp_dbt/models/intermediate/firebase/native/int_firebase__native_attribution.sql
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/firebase/native/int_firebase__native_attribution.sql
@@ -1,0 +1,38 @@
+WITH campaigns AS (
+  SELECT
+    user_pseudo_id,
+    traffic_campaign,
+    traffic_medium,
+    traffic_source,
+    MIN(event_timestamp) AS campaign_begins_at,
+    TIMESTAMP_ADD(MIN(event_timestamp), INTERVAL 1 DAY) AS original_campaign_ends_at
+FROM {{ ref("int_firebase__native_event_flattened") }}
+  WHERE
+    traffic_campaign IS NOT NULL AND traffic_source IS NOT NULL
+    AND event_date BETWEEN '2023-12-20' AND '2024-04-04'
+  GROUP BY
+    user_pseudo_id,
+    traffic_campaign,
+    traffic_medium,
+    traffic_source
+),
+campaigns_with_next_begin AS (
+  SELECT
+    *,
+    LEAD(campaign_begins_at) OVER (PARTITION BY user_pseudo_id ORDER BY campaign_begins_at) AS next_campaign_begins_at
+  FROM
+    campaigns
+)
+SELECT
+  user_pseudo_id,
+  traffic_campaign,
+  traffic_medium,
+  traffic_source,
+  campaign_begins_at,
+  IF(
+    next_campaign_begins_at IS NOT NULL AND next_campaign_begins_at < original_campaign_ends_at,
+    next_campaign_begins_at,
+    original_campaign_ends_at
+  ) AS campaign_ends_at
+FROM
+  campaigns_with_next_begin

--- a/orchestration/dags/data_gcp_dbt/models/intermediate/firebase/native/schema.yml
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/firebase/native/schema.yml
@@ -2,6 +2,17 @@ version: 2
 
 macros:
 
+  - name: int_firebase__native_attribution
+    description: "This table was created following this ticket : 
+    https://www.notion.so/passcultureapp/Sessions-marketing-Fix-donn-es-T1-2024-8fd77bdb6bbd47de8e1bd0d33bc83707
+  
+    There was a parameter mistake in Firebase : 
+    Before, to track the impact of Marketing campaigns, we attributed a campaign to a user within the 24 hours that followed. 
+    But in Firebase, this parameter changed and was replaced by 6 months. 
+    The error has been corrected, but the data related to the campaigns are therefore incorrect between 20/12/23 04/04/24 included. 
+    We created this model to override Firebase's campaign data between these two dates (this override is made in int_firebase__event model).
+    "
+
   - name: int_firebase__native_event
     description: ""
 


### PR DESCRIPTION
# DA PR

## Describe your changes

This PR was created following [this ticket](https://www.notion.so/passcultureapp/Sessions-marketing-Fix-donn-es-T1-2024-8fd77bdb6bbd47de8e1bd0d33bc83707). There was a parameter mistake in Firebase : 

Before, to track the impact of Marketing campaigns, we attributed a campaign to a user within the 24 hours that followed. 
But in Firebase, this parameter changed and was replaced by 6 months. 
The error has been corrected, but the data related to the campaigns are therefore incorrect between 20/12/23 04/04/24 included. We created this model to override Firebase's campaign data between these two dates (this override is made in `int_firebase__event` model).

Tag a reviewer if necessacy  @MatthieuRipollPass @MatthieuRipollPassCulture 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [ ] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [x] New table (non-breaking change)
- [x] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] Fields have been snake_cased
- [ ] I have checked my modifications don't break downstream models
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag in cases of dependencies
- [ ] My code passes CI/CD tests
- [ ] I will post on slack review channel and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)