### PR TITLE
(dbt) Remove mrt_global__offer partition

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/mart/global/mrt_global__offer.sql
+++ b/orchestration/dags/data_gcp_dbt/models/mart/global/mrt_global__offer.sql
@@ -1,13 +1,3 @@
-{{
-    config(
-        partition_by={
-            "field": "offer_creation_date",
-            "data_type": "date"
-        },
-        on_schema_change = "sync_all_columns"
-    )
-}}
-
 SELECT
     offer_id,
     offer_product_id,


### PR DESCRIPTION
# DE PR

## Describe your changes

We observed that Metabase cards and models utilizing `mrt_global__offer` were slower compared to when they used `enriched_offer_data`. The only difference between the two tables is that one is partitioned and the other is not.

Tag a reviewer if necessacy  @LucileRainteau 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [ ] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [ ] New table (non-breaking change)
- [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] I have updated the dag
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket
