### PR TITLE
[HOTFIX](mart) fix: use unique session_id from consultation for (daily-home-reco)

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/mart/native/mrt_native__daily_home_recommendation_offer.sql
+++ b/orchestration/dags/data_gcp_dbt/models/mart/native/mrt_native__daily_home_recommendation_offer.sql
@@ -82,7 +82,7 @@ SELECT
   oc.parent_entry_id,
   oc.parent_home_type,
   oc.module_type,
-  mc.unique_session_id, 
+  oc.unique_session_id, 
   mc.booking_id,
   MAX(mc.consult_offer_timestamp) as consult_offer_timestamp,
   MAX(mc.booking_timestamp) as booking_timestamp,


### PR DESCRIPTION
# Hotfix

## Describe your changes

Please include a summary of the changes:
Changes the unique_session_id alias in order to have it for all events and not only bookings.

This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Tag a reviewer if necessacy  @carolinemestre-passculture 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [ ] I will create a review on slack. The review task should be short (<10min).