### PR TITLE
De-hash address in beneficiary_fraud_check

### DIFF
--- a/orchestration/dags/dependencies/applicative_database/sql/raw/beneficiary_fraud_check.sql
+++ b/orchestration/dags/dependencies/applicative_database/sql/raw/beneficiary_fraud_check.sql
@@ -8,7 +8,7 @@ SELECT
     , status
     , eligibility_type
     , thirdpartyid
-    , regexp_replace(content, \'"(email|phone|lastName|birthDate|firstName|phoneNumber|reason_code|account_email|last_name|birth_date|first_name|phone_number|address|id_piece_number)": "[^"]*",\' ,\'"\\1":"XXX",\', \'g\') as result_content
+    , regexp_replace(content, \'"(email|phone|lastName|birthDate|firstName|phoneNumber|reason_code|account_email|last_name|birth_date|first_name|phone_number|id_piece_number)": "[^"]*",\' ,\'"\\1":"XXX",\', \'g\') as result_content
 FROM (
     SELECT
         CAST("id" AS varchar(255)) AS id


### PR DESCRIPTION
To keep track of users who switched adresses

# DA PR

## Describe your changes

Please include a summary of the changes:

This PR de-hashes address information stored in beneficiary_fraud_check_table when user completes/updates profile informations.

Tag a reviewer if necessacy  @cdelabre 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [x] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [ ] New table (non-breaking change)
- [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [ ] Fields have been snake_cased
- [ ] I have checked my modifications don't break downstream models
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag in cases of dependencies
- [ ] My code passes CI/CD tests
- [ ] I will post on slack review channel and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)