### PR TITLE
HOTFIX: set logbook to 1.6.0 in orchestration requirements.txt

### DIFF
--- a/.github/workflows/reusable_dbt_workflow.yml
+++ b/.github/workflows/reusable_dbt_workflow.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.10'
       - uses: yezz123/setup-uv@v4
       - name: "Install Python requirements"
-        run: uv pip install --system -r airflow/orchestration-requirements.txt
+        run: uv pip sync --system airflow/orchestration-requirements.txt
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v2"
         with:

--- a/.github/workflows/reusable_deploy_composer.yml
+++ b/.github/workflows/reusable_deploy_composer.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: '3.10'
       - uses: yezz123/setup-uv@v4
       - name: "Install Python requirements"
-        run: uv pip install --system -r airflow/orchestration-requirements.txt
+        run: uv pip sync --system airflow/orchestration-requirements.txt
       - id: auth
         name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v2"

--- a/.github/workflows/reusable_job_test.yml
+++ b/.github/workflows/reusable_job_test.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: '3.10'
       - uses: yezz123/setup-uv@v4
       - name: "Install Python requirements"
-        run:  uv pip install --system -r requirements.txt
+        run:  uv pip sync --system requirements.txt
       - name: "Run tests"
         run: pytest tests
         env:

--- a/.github/workflows/reusable_linter.yml
+++ b/.github/workflows/reusable_linter.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.10'
       - uses: yezz123/setup-uv@v4
       - name : "Install Black"
-        run: uv pip install --system -r  linter-requirements.txt
+        run: uv pip sync --system linter-requirements.txt
       - name: "Run Black"
         run: black --check --verbose .
       - name: "Post to a Slack channel"

--- a/.github/workflows/reusable_test_orchestration.yml
+++ b/.github/workflows/reusable_test_orchestration.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: '3.10'
       - uses: yezz123/setup-uv@v4
       - name: "Install Python requirements"
-        run: uv pip install --system -r airflow/orchestration-requirements.txt
+        run: uv pip sync --system airflow/orchestration-requirements.txt
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v2"
         with:

--- a/orchestration/airflow/orchestration-requirements.txt
+++ b/orchestration/airflow/orchestration-requirements.txt
@@ -895,7 +895,7 @@ lockfile==0.12.2
     #   -c https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt
     #   apache-airflow
     #   python-daemon
-logbook==1.5.3
+logbook==1.6.0 # HOTFIX: Should be >=1.5.0 and <1.6.0 but there installation fails in github actions (29/07/2024)
     # via dbt-core
 looker-sdk==23.10.0
     # via


### PR DESCRIPTION
# Hotfix

## Describe your changes

Set logbook version in orchestration-requirements.txt to 1.6.0 since 1.5.3 seems to no longer work in the CI (both with uv and pip).

Run which works : https://github.com/pass-culture/data-gcp/actions/runs/10142010907/job/28040502160

Tag a reviewer if necessacy  @github/username 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [ ] I will create a review on slack. The review task should be short (<10min).