### PR TITLE
fix: Fix ranking_training sql query so that diversification does not …

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/recommendation/ml_reco__ranking_endpoint_training.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/recommendation/ml_reco__ranking_endpoint_training.sql
@@ -55,12 +55,10 @@ interact as (
         fsoe.user_id,
         im.item_id,
         sum(is_consult_offer) as consult,
-        sum(is_add_to_favorites + is_booking_confirmation) as booking,
-        max(d.delta_diversification) as delta_diversification
+        sum(is_add_to_favorites + is_booking_confirmation) as booking
     from
         {{ ref('int_firebase__native_event') }} fsoe
         inner join {{ ref('offer_item_ids') }} as im on fsoe.offer_id = im.offer_id
-        left join diversification d on d.item_id = im.item_id
     where
         event_date >= date_sub(current_date, interval 14 day)
         and event_name in (
@@ -78,9 +76,10 @@ transactions as (
         e.*,
         coalesce(i.booking, 0) > 0 as booking,
         (coalesce(i.booking, 0) + coalesce(i.consult, 0)) > 0 as consult,
-        coalesce(i.delta_diversification, 0) as delta_diversification -- get all past events
+        coalesce(d.delta_diversification, 0) as delta_diversification
     from events e
         left join interact i on i.user_id = e.user_id and i.item_id = e.item_id
+        left join diversification d on d.item_id = e.item_id
 )
 
 select


### PR DESCRIPTION
# DS PR

## Describe your changes

* Fix ranking training SQL query so that mean_diversification is not none even if the item has not been booked nor consult by the given user


## Jira ticket number and/or notion link

No ticket

### Type of change

- [ ] hotfix (non-breaking change which fixes an issue)
- [ ] New model
- [ ] Training
- [ ] New features
- [ ] Bug Fix
- [x] Code Refacto
- [ ] Performance Improvements
- [ ] Test
- [ ] CI
- [ ] Config

      
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] I have updated the dag
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have documented the corresponding [notion page](https://www.notion.so/passcultureapp/Team-Data-engineering-Data-science-22ab0eb5ddf34dc2a854d9f0e596e91b)
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket