### PR TITLE
fix: use n1 highmem 16 for retrieval semantic build

### DIFF
--- a/orchestration/dags/jobs/ml/retrieval_vector_semantic_build.py
+++ b/orchestration/dags/jobs/ml/retrieval_vector_semantic_build.py
@@ -41,7 +41,7 @@ gce_params = {
     "instance_type": {
         "dev": "n1-standard-2",
         "stg": "n1-standard-8",
-        "prod": "n1-standard-16",
+        "prod": "n1-highmem-16",
     },
 }
 


### PR DESCRIPTION
# Hotfix

## Describe your changes

We need 59GB at least 
![image](https://github.com/user-attachments/assets/a7238e4e-0958-4e90-a684-6f3f2a658be0)
Edit: 90BB at least
![image](https://github.com/user-attachments/assets/d277e5f7-3cbd-46a3-bebc-ce46cb633cf9)
Edit : All memory 
![image](https://github.com/user-attachments/assets/83c05fc4-bdfd-4a1f-b5a8-a4373b989fcf)


## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [ ] I will create a review on slack. The review task should be short (<10min).