### PR TITLE
DE/clickhouse: add max number of partition in insert block to catchup fast easily

### DIFF
--- a/jobs/etl_jobs/internal/export_clickhouse/core/update.py
+++ b/jobs/etl_jobs/internal/export_clickhouse/core/update.py
@@ -64,7 +64,7 @@ def update_overwrite(
 ) -> None:
     print(f"Will overwrite {dataset_name}.{table_name}. New update : {update_date}")
     CLICKHOUSE_CLIENT.command(
-        f" ALTER TABLE {dataset_name}.{table_name} ON cluster default REPLACE PARTITION '{update_date}' FROM tmp.{tmp_table_name}"
+        f" ALTER TABLE {dataset_name}.{table_name} ON cluster default REPLACE PARTITION '{update_date}' FROM tmp.{tmp_table_name}",
     )
 
     remove_stale_partitions(dataset_name, table_name, update_date)
@@ -91,7 +91,11 @@ def create_intermediate_schema(table_name: str, dataset_name: str) -> None:
 
 
 def create_tmp_schema(
-    sql_file_name: str, table_name: str, update_date: str, source_gs_path: str
+    sql_file_name: str,
+    table_name: str,
+    update_date: str,
+    source_gs_path: str,
+    max_partitions_per_insert_block: int,
 ) -> None:
     CLICKHOUSE_CLIENT.command(
         f"DROP TABLE IF EXISTS tmp.{table_name} ON cluster default"
@@ -109,4 +113,9 @@ def create_tmp_schema(
     )
     print(sql_query)
     print(f"Creating tmp.{table_name} table...")
-    CLICKHOUSE_CLIENT.command(sql_query)
+    CLICKHOUSE_CLIENT.command(
+        sql_query,
+        settings={
+            "max_partitions_per_insert_block": str(max_partitions_per_insert_block)
+        },
+    )

--- a/jobs/etl_jobs/internal/export_clickhouse/main.py
+++ b/jobs/etl_jobs/internal/export_clickhouse/main.py
@@ -10,7 +10,14 @@ from core.update import (
 )
 
 
-def main_update(mode, source_gs_path, table_name, dataset_name, update_date):
+def main_update(
+    mode,
+    source_gs_path,
+    table_name,
+    dataset_name,
+    update_date,
+    max_partitions_per_insert_block=100,
+):
     _id = datetime.now().strftime("%Y%m%d%H%M%S")
     tmp_table_name = f"{table_name}_{_id}"
 
@@ -20,6 +27,7 @@ def main_update(mode, source_gs_path, table_name, dataset_name, update_date):
         table_name=tmp_table_name,
         update_date=update_date,
         source_gs_path=source_gs_path,
+        max_partitions_per_insert_block=max_partitions_per_insert_block,
     )
 
     # create table schema
@@ -65,11 +73,22 @@ def run(
         None,
         help="source_gs_path",
     ),
+    max_partitions_per_insert_block: int = typer.Option(
+        100,
+        help="max number of partition to insert at once",
+    ),
 ):
     if mode in ("incremental", "overwrite"):
         if source_gs_path is None:
             raise Exception("source_gs_path should be specified")
-        main_update(mode, source_gs_path, table_name, dataset_name, update_date)
+        main_update(
+            mode,
+            source_gs_path,
+            table_name,
+            dataset_name,
+            update_date,
+            max_partitions_per_insert_block,
+        )
     else:
         raise Exception(f"wrong specified mode, got {mode} ")
 

--- a/orchestration/dags/jobs/export/export_clickhouse.py
+++ b/orchestration/dags/jobs/export/export_clickhouse.py
@@ -118,6 +118,10 @@ for dag_name, dag_params in dags.items():
                 default=-4,
                 type="integer",
             ),
+            "max_partitions_per_insert_block": Param(
+                default=100,
+                type="integer",
+            ),
         },
     ) as dag:
         branching = BranchPythonOperator(
@@ -231,7 +235,8 @@ for dag_name, dag_params in dags.items():
                 f"--table-name {clickhouse_table_name} "
                 f"--dataset-name {clickhouse_dataset_name} "
                 f"--update-date {_ds} "
-                f"--mode {mode} ",
+                f"--mode {mode} "
+                f"--max-partitions-per-insert-block {{{{ params.max_partitions_per_insert_block }}}} ",
             )
             export_task >> export_bq >> clickhouse_export
             out_tables_tasks.append(clickhouse_export)


### PR DESCRIPTION
# DE PR

## Describe your changes

Please include a summary of the changes:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 

Tag a reviewer if necessacy  @github/username 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [ ] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [ ] New table (non-breaking change)
- [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] I have updated the dag
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket
