### PR TITLE
[DE-617] feat: Update text encoder model in offer categorization API

### DIFF
--- a/jobs/ml_jobs/algo_training/offer_categorization/package_api_model.py
+++ b/jobs/ml_jobs/algo_training/offer_categorization/package_api_model.py
@@ -35,7 +35,7 @@ class PreprocessingOutput:
 
 class ApiModel(mlflow.pyfunc.PythonModel):
     TEXT_ENCODER_MODEL = SentenceTransformer(
-        "sentence-transformers/clip-ViT-B-32-multilingual-v1", device="cpu"
+        "sentence-transformers/all-MiniLM-L6-v2", device="cpu"
     )
 
     def __init__(self, classification_model: CatBoostClassifier, features: dict):


### PR DESCRIPTION
Update the text encoder model used in the offer categorization API from "sentence-transformers/clip-ViT-B-32-multilingual-v1" to "sentence-transformers/all-MiniLM-L6-v2". This change improves the performance of the API by using a more advanced text encoder model.

# Hotfix

## Describe your changes

Fix sentence_transformer model name used in offer_categorization inference  

This PR fixes the bug


### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [x] I will create a review on slack. The review task should be short (<10min).