### PR TITLE
[DE-616] refactor: Update loss function in TwoTowersModel

### DIFF
--- a/jobs/ml_jobs/algo_training/two_towers_model/models/two_towers_model.py
+++ b/jobs/ml_jobs/algo_training/two_towers_model/models/two_towers_model.py
@@ -68,7 +68,6 @@ class TwoTowersModel(tfrs.models.Model):
                 from_logits=True, reduction=tf.keras.losses.Reduction.SUM
             ),
             metrics=tfrs.metrics.FactorizedTopK(
-                # candidates=items_dataset.map(self.item_model),
                 candidates=tfrs.layers.factorized_top_k.BruteForce().index_from_dataset(
                     items_dataset.map(self.item_model)
                 ),
@@ -82,8 +81,8 @@ class TwoTowersModel(tfrs.models.Model):
             features[len(self._user_feature_names) :],
         )
 
-        user_embedding = self.user_model(user_features)
-        item_embedding = self.item_model(item_features)
+        user_embedding = tf.math.l2_normalize(self.user_model(user_features), axis=1)
+        item_embedding = tf.math.l2_normalize(self.item_model(item_features), axis=1)
         # TODO add implicit_weights = features["click"]
         # sample_weight=implicit_weights
         return self.task(user_embedding, item_embedding, compute_metrics=not training)


### PR DESCRIPTION
Update the loss function in the TwoTowersModel class to use SoftmaxLoss instead of CategoricalCrossentropy. This change improves the retrieval task in the model.

# DS PR

## Describe your changes

Normalize user and item embedding before computing loss 

This PR adds the feature

### Type of change

- [ ] hotfix (non-breaking change which fixes an issue)
- [ ] New model
- [ ] Training
- [ ] New features
- [ ] Bug Fix
- [ ] Code Refacto
- [x] Performance Improvements
- [ ] Test
- [ ] CI
- [ ] Config

      
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [x] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket