### PR TITLE
add final compile step

### DIFF
--- a/orchestration/dags/jobs/dbt/dbt_artifacts.py
+++ b/orchestration/dags/jobs/dbt/dbt_artifacts.py
@@ -92,10 +92,23 @@ send_elementary_report = BashOperator(
     dag=dag,
 )
 
+compile = BashOperator(
+    task_id="compilation",
+    bash_command=f"bash {PATH_TO_DBT_PROJECT}/scripts/dbt_compile.sh ",
+    env={
+        "target": "{{ params.target }}",
+        "PATH_TO_DBT_TARGET": PATH_TO_DBT_TARGET,
+    },
+    append_env=True,
+    cwd=PATH_TO_DBT_PROJECT,
+    dag=dag,
+)
+
 (
     start
     >> wait_dbt_run
     >> dbt_test
     >> compute_metrics_elementary
     >> send_elementary_report
+    >> compile
 )


### PR DESCRIPTION
# Hotfix

## Describe your changes

known issue - see elementary-commmunity slack:

Renee Cooper
  Le 31 juil. 2023 à 17 h 08
Has anyone run into issues with their dbt docs since upgrading Elementary to the latest version?  I upgrade Elementary in packages to 0.9.0. (and the package in requirements to 0.9.1).
Post-upgrade, our published dbt docs only have the Elementary models & dbt_utils; all our models are missing.
Logging into the dbt-test kubernetes pod before it exits, I can see both the manifest.json and the catalog.json are new.  I downloaded them and while the catalog.json has our model information, the manifest only has Elementary information.
In the pod we do in this order:
dbt test
edr monitor
dbt docs generate
edr report
app deploy (of the GCP app; uploads the files)
I cannot run edr report locally to see if that's what's overwriting the manifest with Elementary-only data because it just errors out with that AuthMetadataPlugin error.  Locally, dbt docs generate works fine; both the catalog.json and the manifest.json have our company specific models.
Did anything change about how the manifest is created in Elementary 0.9.0?
7 réponses


Ella Katz
:elementary-magenta:  [Le 3 août 2023 à 15 h 29](https://elementary-community.slack.com/archives/C02CTC89LAX/p1691069386731569?thread_ts=1690816110.288819&cid=C02CTC89LAX)
Hi 
[@Renee Cooper](https://elementary-community.slack.com/team/U057SD8CBEY)
,
Did you see my response on your other thread? How's it going? Still need help with the upgrade?


Artur Peedimaa
  Le 13 sept. 2023 à 20 h 33
Hi, I've actually just stumbled upon this issue myself.
Using dbt-core 1.5.1 and elementary 0.10.3
After running edr monitor (or edr rerort) the target/manifest.json is overwritten by elementary.
The workaround right now seems to be that we publish/upload the manifest.json before running edr monitor (we use the manifest for state comparison).
But is it intended behaviour that the dbt manifest is overwritten instead of, let's say, writing it to edr_target/manifest.json ?
Thank you in advance. (modifié) 


Renee Cooper
  [Le 13 sept. 2023 à 20 h 47](https://elementary-community.slack.com/archives/C02CTC89LAX/p1694630872848419?thread_ts=1690816110.288819&cid=C02CTC89LAX)
Yes, we had to change the order of operations in order to get our report to work.
:+1:
1



Renee Cooper
  [Le 13 sept. 2023 à 20 h 55](https://elementary-community.slack.com/archives/C02CTC89LAX/p1694631301400619?thread_ts=1690816110.288819&cid=C02CTC89LAX)
But I agree -- it's very odd that it overwrites it like this; it did not before, right?  I'm just wondering why so few folks have not run into it.


Artur Peedimaa
  Le 13 sept. 2023 à 20 h 57
I'm not sure how it worked before (with earlier versions), unfortunately, as we started using elementary just now and ran into the issue when I noticed that suddenly the slim ci wants to run most of our models. :cri:






Ella Katz
:elementary-magenta:  [Le 14 sept. 2023 à 10 h 11](https://elementary-community.slack.com/archives/C02CTC89LAX/p1694679066810709?thread_ts=1690816110.288819&cid=C02CTC89LAX)
Hi 
[@Artur Peedimaa](https://elementary-community.slack.com/team/U056ZS2HPV3)
, 
[@Renee Cooper](https://elementary-community.slack.com/team/U057SD8CBEY)
,
Thanks for flagging this! We'll look into it and keep you posted :prière:
:+1:
1



Artur Peedimaa
  [Le 14 sept. 2023 à 12 h 11](https://elementary-community.slack.com/archives/C02CTC89LAX/p1694686279982239?thread_ts=1690816110.288819&cid=C02CTC89LAX)
Awesome, thanks.

Tag a reviewer if necessacy  @github/username 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag
- [ ] I will create a review on slack. The review task should be short (<10min).