### PR TITLE
Fix Propilote KPIs for september EAC metrics

### DIFF
--- a/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_ecoles/propilote_tmp_participation_eac_ecoles.sql
+++ b/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_ecoles/propilote_tmp_participation_eac_ecoles.sql
@@ -9,7 +9,7 @@ WHERE educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 yea
 SELECT 
     DATE_TRUNC(date,MONTH) AS date,
     MAX(date) AS last_date,
-    MAX(adage_id) AS last_adage_id
+    MAX(CAST(adage_id AS INT)) AS last_adage_id
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_institution`
 WHERE 
     date <= current_date 
@@ -32,7 +32,7 @@ SELECT
     , SUM(total_institutions) AS denominator -- total_institutions
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_institution` as involved
 -- take only last day for each month.
-JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date AND last_day.last_adage_id = involved.adage_id
+JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date AND last_day.last_adage_id = CAST(involved.adage_id AS INT)
 LEFT JOIN `{{ bigquery_analytics_dataset }}.region_department` as rd
     ON involved.department_code = rd.num_dep
 WHERE

--- a/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_jeunes/propilote_tmp_participation_eac_jeunes.sql
+++ b/orchestration/dags/dependencies/propilote/sql/tmp/taux_participation_eac_jeunes/propilote_tmp_participation_eac_jeunes.sql
@@ -9,7 +9,7 @@ WHERE educational_year_beginning_date <= DATE_SUB(current_date(), interval 1 yea
 SELECT 
     DATE_TRUNC(date,MONTH) AS date,
     MAX(date) AS last_date,
-    MAX(adage_id) AS last_adage_id
+    MAX(CAST(adage_id AS INT)) AS last_adage_id
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_student`
 WHERE 
     date <= current_date 
@@ -32,7 +32,7 @@ SELECT
     , SUM(total_involved_students) AS denominator -- students_eligible
 FROM `{{ bigquery_analytics_dataset }}.adage_involved_student` as involved
 -- take only last day for each month.
-JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date AND last_day.last_adage_id = involved.adage_id
+JOIN last_day ON last_day.last_date = involved.date AND DATE_TRUNC(involved.date,MONTH) = last_day.date AND last_day.last_adage_id = CAST(involved.adage_id AS INT)
 LEFT JOIN `{{ bigquery_analytics_dataset }}.region_department` as rd
     ON involved.department_code = rd.num_dep
 -- on selectionne uniquement l'année scolaire qui correspond à la date de calcul


### PR DESCRIPTION
# DA PR

## Describe your changes

Please include a summary of the changes:

This PR fixes missing data for EAC Propilote KPIs for the month of september (ppg_index 9 and 10). Because adage_id was treated as a STRING rather than an INT, last_adage_id for september was 9 and not 10

Tag a reviewer if necessacy  @LucileRainteau @cdelabre 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [x] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [ ] New table (non-breaking change)
- [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [ ] Fields have been snake_cased
- [ ] I have checked my modifications don't break downstream models
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag in cases of dependencies
- [ ] My code passes CI/CD tests
- [ ] I will post on slack review channel and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)