### PR TITLE
(DA-3744) fix(bq_jobs): Fix user_is_unemployed column in user table

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/intermediate/global/int_global__user.sql
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/global/int_global__user.sql
@@ -54,11 +54,11 @@ select
     ui.user_density_level,
     ui.user_city_code as city_code,
     ui.user_is_in_qpv,
-    case when u.user_activity in ("Chômeur", "En recherche d'emploi ou chômeur","Demandeur d'emploi") then TRUE else FALSE end as user_is_unemployed,
+    case when u.user_activity = "Chômeur, En recherche d'emploi" then TRUE else FALSE end as user_is_unemployed,
     case when
             (
                 (ui.qpv_name is not NULL)
-                or (u.user_activity in ("Chômeur", "En recherche d'emploi ou chômeur","Demandeur d'emploi"))
+                or (u.user_activity = "Chômeur, En recherche d'emploi")
                 or (ui.user_macro_density_label = "rural")
             )
             then TRUE


### PR DESCRIPTION
# DA PR

## Describe your changes

Please include a summary of the changes:

This PR fixes user_is_unemployed column (wrong string value expected)

Tag a reviewer if necessacy  @LucileRainteau @Jules-Arbelot 

## Jira ticket number and/or notion link

JIRA-ticket_number

### Type of change
- [x] Fix (non-breaking change which corrects expected behavior)
- [ ] New fields (non-breaking change)
- [ ] New table (non-breaking change)
- [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts) 
- [ ] Table deletion (potentially breaking change which adds functionality/ table)
      
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Fields have been snake_cased
- [ ] I have checked my modifications don't break downstream models
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
- [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
- [ ] I have updated the dag in cases of dependencies
- [ ] My code passes CI/CD tests
- [x] I will post on slack review channel and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)