### PR TITLE
(DE-433) fix(netskope): install airflow via netskope

### DIFF
--- a/orchestration/.gitignore
+++ b/orchestration/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+*.pem

--- a/orchestration/Makefile
+++ b/orchestration/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 build:
 	docker compose down -v;
 	docker compose build --no-cache;

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -67,6 +67,10 @@ On peut qu'avoir une version de Airflow installé en local. Pour pallier ça, il
 2. Récupérer le fichier .env et le mettre dans `orchestration/.env`
    - Modifier les valeurs de _AIRFLOW_WWW_USER_USERNAME et _AIRFLOW_WWW_USER_PASSWORD dans le fichier .env
    - Modifier la valeur du DAG_FOLDER
+3. Si l'ordinateur est soumis à une Proxy Netskope:
+    - Récupérer le certificat bundled ou combiné de la machine locale. Voir [cette page notion](https://www.notion.so/passcultureapp/Proxyfication-des-outils-du-pass-d1f0da09eafb4158904e9197bbe7c1d4?pvs=4#10cad4e0ff98805ba61efcea26075d65) si on ne trouve pas tout de suite le fichier `*_combined.pem`.
+    - Mettre le fichier `.pem` dans `/orchestration`
+    - Modifier la valeur du champ `CERT_FILE_LOCAL` pour spécifier le path du fichier `.pem`.
 
 ### Premier lancement (La première fois uniquement)
 sur macos installer la lib coreutils `brew install coreutils`

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -71,6 +71,7 @@ On peut qu'avoir une version de Airflow installé en local. Pour pallier ça, il
     - Récupérer le certificat bundled ou combiné de la machine locale. Voir [cette page notion](https://www.notion.so/passcultureapp/Proxyfication-des-outils-du-pass-d1f0da09eafb4158904e9197bbe7c1d4?pvs=4#10cad4e0ff98805ba61efcea26075d65) si on ne trouve pas tout de suite le fichier `*_combined.pem`.
     - Mettre le fichier `.pem` dans `/orchestration`
     - Modifier la valeur du champ `CERT_FILE_LOCAL` pour spécifier le path du fichier `.pem`.
+4. Sinon, la valeur du champ `CERT_FILE_LOCAL` doit être vide.
 
 ### Premier lancement (La première fois uniquement)
 sur macos installer la lib coreutils `brew install coreutils`

--- a/orchestration/airflow/Dockerfile
+++ b/orchestration/airflow/Dockerfile
@@ -1,9 +1,20 @@
 FROM apache/airflow:2.9.1-python3.10
-ARG GCLOUD_SERVICE_KEY=/etc/sa.gcpkey.json
-ARG AIRFLOW_USER_HOME=/opt/airflow
-ARG GCLOUD_VERSION=google-cloud-cli-411.0.0-linux-x86_64.tar.gz
 
-# install airflow deps
+# Define Dockerfile Arguments
+ARG AIRFLOW_USER_HOME=/opt/airflow
+ARG GCLOUD_SERVICE_KEY=/etc/sa.gcpkey.json
+ARG GCLOUD_VERSION=google-cloud-cli-411.0.0-linux-x86_64.tar.gz
+ARG CERT_PATH_DOCKER=/usr/local/share/ca-certificates/nscacert.pem
+
+# Define Dockerfile Arguments imported from the .env file
+ARG CERT_FILE_LOCAL=$CERT_FILE_LOCAL
+
+# Set environment variales for SSL certficate
+COPY ${CERT_FILE_LOCAL} ${CERT_PATH_DOCKER}
+ENV REQUESTS_CA_BUNDLE=${CERT_PATH_DOCKER}
+ENV SSL_CERT_FILE=${CERT_PATH_DOCKER}
+
+# Install airflow deps
 WORKDIR ${AIRFLOW_USER_HOME}
 COPY airflow/orchestration-requirements.txt /opt/requirements.txt
 RUN uv pip install --no-cache-dir -r /opt/requirements.txt
@@ -12,12 +23,15 @@ RUN uv pip install --no-cache-dir -r /opt/requirements.txt
 COPY dags/data_gcp_dbt/dbt-requirements.txt /opt/dbt-requirements.txt
 RUN uv pip install --no-cache-dir -r /opt/dbt-requirements.txt
 
-# install gcloud
+# Install gcloud
 USER root
-RUN apt-get update && apt-get install -y git ca-certificates --no-install-recommends
+RUN apt-get update && apt-get install -y git ca-certificates --no-install-recommends && update-ca-certificates
 COPY ./airflow/etc/sa.gcpkey.json ${GCLOUD_SERVICE_KEY}
 RUN curl -LO -k https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_VERSION} && tar xf ${GCLOUD_VERSION}
 ENV PATH=$PATH:$AIRFLOW_USER_HOME/google-cloud-sdk/bin
+RUN if [ -f "${CERT_PATH_DOCKER}" ]; then \
+        gcloud config set core/custom_ca_certs_file ${CERT_PATH_DOCKER}; \
+    fi
 RUN gcloud auth activate-service-account --key-file=${GCLOUD_SERVICE_KEY}
 
 

--- a/orchestration/docker-compose.yaml
+++ b/orchestration/docker-compose.yaml
@@ -70,6 +70,8 @@ services:
     build:
       context: .
       dockerfile: ./airflow/Dockerfile
+      args:
+        - CERT_FILE_LOCAL=${CERT_FILE_LOCAL:-}
     <<: *airflow-common
     command: "airflow db init"
     environment:


### PR DESCRIPTION

* [DE](?expand=1&template=DE_ticket_template.md)

## (DE-433) fix(netskope): install airflow via netskope
* **Modification to the .env file** : add `CERT_FILE_LOCAL` field which contains the path to the certificate if machine with netskope and shoukd be left empty if no netskope
* **Modification to Dockerfile** : I cannot do an `if else` to set the `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` environment variables by doing `RUN export` instead of `ENV` because Docker will not set the variables (see this [SO thread ](https://stackoverflow.com/questions/67792050/dockerfile-bash-export-statement-not-working)). However, the gcloud config certifcate command could and has to be set with an if else, which is done in the Dockerfile. 
* **This code works fine for a machine with netskope, and should be tested with a machine without netskope.**. The idea is that we let docker set the `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` environment variables  to an empty path and hope that since no proxy, these variables won't be called by the `uv install`



