### PR TITLE
(DA-3536) feat(analytics): Add field venue_is_open_to_public to venue tables

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
@@ -13,6 +13,7 @@
 {% docs column__venue_managing_offerer_id %} ID of the offerer who manage the venue. One offerer can have multiple venues. {% enddocs %}
 {% docs column__venue_creation_date %} Date when the venue was created on the application. {% enddocs %}
 {% docs column__venue_is_permanent %} Indicates if the venue is permanent. A permanent venue is a venue that can receive public permanently, that can propose offers, and that is managed by the partner. Permanent venues exemple : a library, a cinema. Non permanent venues example : a public garden that hosted a festival once, or a theater that hosted a concert once - it can be permanent for the partner who owns the theater, but not for the partner who is hosted once in this place. {% enddocs %}
+{% docs column__venue_is_open_to_public %} This field will replace the venue_is_permanent field (mid-2025), as part of the offer-adresse project. It is a venue that can receive public permanently, that can propose offers, and that is managed by the partner. {% enddocs %}
 {% docs column__venue_is_acessibility_synched %} Indicates if the venue's accessibility is synchronized. {% enddocs %}
 {% docs column__venue_type_label %} Type of the venue ('Musée', 'Cinéma','Librairie', etc). Selected by the partner in a drop-down list. {% enddocs %}
 {% docs column__venue_label %} Label of the venue. The label is appended by the Ministry as token of quality and standing in its category. {% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
@@ -38,8 +38,6 @@
 {% docs column__venue_in_qpv %}Indicates whether the venue is in a
 City Policy Priority Neighborhood.{% enddocs %}
 {% docs column__venue_image_source %}Origin of venue image : google, offerer, default_category.{% enddocs %}
-{% docs column__banner_url %}Venue image url.{% enddocs %}
-{% docs column__venue_density_level %}Venue density level from 1 to 7.{% enddocs %}
 
 /* To rename into venue_*** */
 {% docs column__is_active_last_30days %} Analytical field: Indicates if it was active in the last 30 days. {% enddocs %}
@@ -48,3 +46,4 @@ City Policy Priority Neighborhood.{% enddocs %}
 {% docs column__is_individual_active_current_year %} Analytical field: Indicates if it has individual activity in the current year. {% enddocs %}
 {% docs column__is_collective_active_last_30days %} Analytical field: Indicates if it had collective activity in the last 30 days. {% enddocs %}
 {% docs column__is_collective_active_current_year %} Analytical field: Indicates if it has collective activity in the current year. {% enddocs %}
+{% docs column__banner_url %}Venue image url.{% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
@@ -37,7 +37,6 @@
 {% docs column__venue_has_siret %}Indicates whether the venue has a SIRET.{% enddocs %}
 {% docs column__venue_in_qpv %}Indicates whether the venue is in a
 City Policy Priority Neighborhood.{% enddocs %}
-{% docs column__venue_department_name %}Department name where the venue is located.{% enddocs %}
 {% docs column__venue_image_source %}Origin of venue image : google, offerer, default_category.{% enddocs %}
 {% docs column__banner_url %}Venue image url.{% enddocs %}
 {% docs column__venue_density_level %}Venue density level from 1 to 7.{% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/glossary/applicative_database/column__venue.md
@@ -35,6 +35,12 @@
 {% docs column__venue_density_level %} ID of the density level of the venue (cf venue_density_label). {% enddocs %}
 {% docs column__venue_department_name %} Department name where of the venue. {% enddocs %}
 {% docs column__venue_has_siret %}Indicates whether the venue has a SIRET.{% enddocs %}
+{% docs column__venue_in_qpv %}Indicates whether the venue is in a
+City Policy Priority Neighborhood.{% enddocs %}
+{% docs column__venue_department_name %}Department name where the venue is located.{% enddocs %}
+{% docs column__venue_image_source %}Origin of venue image : google, offerer, default_category.{% enddocs %}
+{% docs column__banner_url %}Venue image url.{% enddocs %}
+{% docs column__venue_density_level %}Venue density level from 1 to 7.{% enddocs %}
 
 /* To rename into venue_*** */
 {% docs column__is_active_last_30days %} Analytical field: Indicates if it was active in the last 30 days. {% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/intermediate/applicative/int_applicative__venue.sql
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/applicative/int_applicative__venue.sql
@@ -127,6 +127,7 @@ select
     v.venue_label_id,
     v.venue_creation_date,
     v.venue_is_permanent,
+    v.venue_is_open_to_public,
     v.banner_url,
     v.venue_audiodisabilitycompliant,
     v.venue_mentaldisabilitycompliant,

--- a/orchestration/dags/data_gcp_dbt/models/intermediate/global/int_global__venue.sql
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/global/int_global__venue.sql
@@ -15,6 +15,7 @@ select
     v.venue_managing_offerer_id,
     v.venue_creation_date,
     v.venue_is_permanent,
+    v.venue_is_open_to_public,
     v.venue_is_acessibility_synched,
     v.venue_type_label,
     v.venue_label,

--- a/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__venue.yml
+++ b/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__venue.yml
@@ -286,7 +286,7 @@ models:
           - not_null
       - name: offerer_address_id
         description: '{{ doc("column__offerer_address_id") }}'
-        data_type: INT64
+        data_type: STRING
       - name: offerer_rank_desc
         description: '{{ doc("column__offerer_rank_desc") }}'
         data_type: INT64
@@ -294,7 +294,17 @@ models:
         description: '{{ doc("column__offerer_rank_asc") }}'
         data_type: INT64
       - name: venue_density_level
+        description: '{{ doc("column__venue_density_level") }}'
+        data_type: STRING
       - name: venue_in_qpv
+        description: '{{ doc("column__venue_in_qpv") }}'
+        data_type: BOOLEAN
       - name: venue_department_name
+        description: '{{ doc("column__venue_department_name") }}'
+        data_type: STRING
       - name: banner_url
+        description: '{{ doc("column__banner_url") }}'
+        data_type: STRING
       - name: venue_image_source
+        description: '{{ doc("column__venue_image_source") }}'
+        data_type: STRING

--- a/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__venue.yml
+++ b/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__venue.yml
@@ -293,3 +293,8 @@ models:
       - name: offerer_rank_asc
         description: '{{ doc("column__offerer_rank_asc") }}'
         data_type: INT64
+      - name: venue_density_level
+      - name: venue_in_qpv
+      - name: venue_department_name
+      - name: banner_url
+      - name: venue_image_source

--- a/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__venue.yml
+++ b/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__venue.yml
@@ -55,6 +55,9 @@ models:
       - name: venue_is_permanent
         description: '{{ doc("column__venue_is_permanent") }}'
         data_type: BOOLEAN
+      - name: venue_is_open_to_public
+        description: '{{ doc("column__venue_is_open_to_public") }}'
+        data_type: BOOLEAN
       - name: venue_is_acessibility_synched
         description: '{{ doc("column__venue_is_acessibility_synched") }}'
         data_type: BOOLEAN

--- a/orchestration/dags/data_gcp_dbt/models/mart/global/mrt_global__venue.sql
+++ b/orchestration/dags/data_gcp_dbt/models/mart/global/mrt_global__venue.sql
@@ -15,6 +15,7 @@ select
     venue_managing_offerer_id,
     venue_creation_date,
     venue_is_permanent,
+    venue_is_open_to_public,
     venue_is_acessibility_synched,
     venue_type_label,
     venue_label,

--- a/orchestration/dags/dependencies/applicative_database/sql/raw/parallel/venue.sql
+++ b/orchestration/dags/dependencies/applicative_database/sql/raw/parallel/venue.sql
@@ -59,6 +59,6 @@ SELECT
     , "dmsToken" AS dms_token
     , "description" AS venue_description
     , "withdrawalDetails" AS venue_withdrawal_details
-    , "offererAddressId" AS offerer_address_id
+    , CAST("offererAddressId"AS varchar(255)) AS offerer_address_id
     , "isOpenToPublic" AS venue_is_open_to_public
 FROM public.venue

--- a/orchestration/dags/dependencies/applicative_database/sql/raw/parallel/venue.sql
+++ b/orchestration/dags/dependencies/applicative_database/sql/raw/parallel/venue.sql
@@ -60,4 +60,5 @@ SELECT
     , "description" AS venue_description
     , "withdrawalDetails" AS venue_withdrawal_details
     , "offererAddressId" AS offerer_address_id
+    , "isOpenToPublic" AS venue_is_open_to_public
 FROM public.venue


### PR DESCRIPTION
-> Le champs venue_is_open_to_public vise à remplacer progressivement le champs venue_is_permanent dans le cadre du rattrapage des lieux relatifs au chantier offre-adresse. 
A date : 
<img width="965" alt="image" src="https://github.com/user-attachments/assets/7be2e984-e441-4c3b-9eb1-1dbff6cec909">

