### PR TITLE
(HF) fix(metrics): filter offers_to_score to only keep those of the 5000 users

### DIFF
--- a/jobs/ml_jobs/algo_training/two_towers_model/utils/evaluate.py
+++ b/jobs/ml_jobs/algo_training/two_towers_model/utils/evaluate.py
@@ -78,6 +78,10 @@ def generate_predictions(
         pd.DataFrame: DataFrame with columns ['user_id', 'item_id', 'score'], where score represents
                         the predicted interaction score (dot product between user and item two tower embeddings).
     """
+    ## TODO UNCOMMENT THIS AFTER BATCHING IS DONE
+    ## Get unique items to score
+    # offers_to_score = test_data.item_id.unique()
+    # logger.info(f"Number of unique items to score: {len(offers_to_score)}")
 
     ## Truncate test data if not all users are to be evaluated
     total_n_users = len(test_data["user_id"].unique())
@@ -90,7 +94,7 @@ def generate_predictions(
     else:
         logger.info(f"Computing metrics for all users ({total_n_users}) users)")
 
-    # Get unique items to score TODO DELETE THIS AFTER HOTFIX PASSES
+    # TODO DELETE THIS AFTER BATCHING IS DONE
     offers_to_score = test_data.item_id.unique()
     logger.info(f"Number of unique items to score: {len(offers_to_score)}")
 


### PR DESCRIPTION
# Hotfix

## Describe your changes

Please include a summary of the changes:

* This PR filters the offers_to_score to keep the ones associated with the users_to_test and not all items in test_dataset

## Jira ticket number and/or notion link

JIRA-ticket_number

### Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] My code passes CI/CD tests
* [ ] I have made corresponding changes to the [tables documentation](https://www.notion.so/passcultureapp/Documentation-Tables-175a397a8e854ff4a55ae4f3620dbe3b)
* [ ] I have made corresponding changes to the [fields glossary](https://www.notion.so/passcultureapp/854a436a8f1541e1b6ec2a65f8bab600?v=798024ba90404b139e5a17407a3bc604)
* [ ] I have updated the dag
* [ ] I will create a review on slack. The review task should be short (<10min).

### PR title format (except for MEP)

There is a linter on the PR title format. Please respect the following format:

<details>
<summary>(ticket) type(topic): comment</summary>

* ticket surrounded by parenthesis, with optionnaly a hyphen followed by one or more digits (e.g., -1234). The first part must be one of the following strings:
  * DA
  * DE
  * AE
  * DS
  * HF
  * BSR
  * PC

* type :
The second part to specify the type of change one of the following :
  * build
  * lint
  * ci
  * docs
  * feat
  * fix
  * perf
  * refactor
  * test
  * chore
  * dbt

* topic within parenthesis: 1 word e.g., (dag)

* comment: tell us your life

examples:

* :white_check_mark: (DE-124) refactor(firebase): update source field
* :x: (DE-124) refactor (firebase): update source field **(space between type and topic)**
* :x: (DE-124) airflow(firebase): update source fiedd in DAG **(wrong type)**
* :x: (DE-124) (DE-124) refactor(firebase refacto): update source field **(topic in two words)**
* :white_check_mark: (BSR) docs(github): add PR title valid format in template

</details>
