### PR TITLE
(DE) fix(siren): replace deprecated df.to_gbq() with pandas_gbq.to_gbq()

### DIFF
--- a/jobs/etl_jobs/external/siren/scripts/import_siren.py
+++ b/jobs/etl_jobs/external/siren/scripts/import_siren.py
@@ -2,6 +2,7 @@ import time
 from datetime import datetime, timedelta
 
 import pandas as pd
+import pandas_gbq
 import requests
 from google.cloud import bigquery
 
@@ -182,8 +183,9 @@ def siren_to_bq():
 def save_to_bq(siren_list):
     df = pd.DataFrame(siren_list)
     df["update_date"] = datetime.now().strftime("%Y-%m-%d")
-    df.to_gbq(
-        f"""{BIGQUERY_CLEAN_DATASET}.siren_data""",
+    pandas_gbq.to_gbq(
+        df,
+        f"{BIGQUERY_CLEAN_DATASET}.siren_data",
         project_id=GCP_PROJECT,
         if_exists="append",
     )


### PR DESCRIPTION
## Summary
Since pandas 2.0, the `DataFrame.to_gbq()` accessor was removed and `pandas_gbq` is no longer bundled. This caused the SIREN ETL job to crash at the BigQuery save step with an `AttributeError`.

## Changes
- Added explicit `import pandas_gbq` in `import_siren.py`
- Replaced `df.to_gbq(destination, ...)` with `pandas_gbq.to_gbq(df, destination, ...)` (the correct standalone call)

## Related
- No ticket — hotfix for broken ETL job in stg

## Testing
- Validated locally that `pandas_gbq` is already declared as a dependency in `pyproject.toml` (`pandas-gbq>=0.23.1`)
- Error reproduced from Airflow logs on `passculture-data-ehp` / `stg`