### PR TITLE
(DE-3116) refactor(artist): match existing unmatched artists to Wikidata in refresh_artist_metadatas

### DIFF
--- a/jobs/ml_jobs/artist_linkage/cli/link_new_products_to_artists.py
+++ b/jobs/ml_jobs/artist_linkage/cli/link_new_products_to_artists.py
@@ -240,7 +240,9 @@ def main(
             [OFFER_CATEGORY_ID_KEY, ARTIST_TYPE_KEY, ARTIST_NAME_TO_MATCH_KEY]
         )
         .agg(
-            tmp_id=(ARTIST_NAME_KEY, lambda x: str(uuid.uuid4())),
+            **{
+                ARTIST_ID_KEY: (ARTIST_NAME_KEY, lambda x: str(uuid.uuid4())),
+            },
             artist_name_set=(ARTIST_NAME_KEY, lambda x: set(x.unique())),
             artist_name_count=(ARTIST_NAME_KEY, "count"),
             artist_name_nunique=(ARTIST_NAME_KEY, "nunique"),

--- a/jobs/ml_jobs/artist_linkage/cli/link_new_products_to_artists.py
+++ b/jobs/ml_jobs/artist_linkage/cli/link_new_products_to_artists.py
@@ -20,13 +20,18 @@ from src.constants import (
 )
 from src.utils.loading import load_wikidata
 from src.utils.matching import (
-    ALIAS_MERGE_COLUMNS,
-    build_artist_alias,
     create_artists_tables,
     match_artist_on_offer_names,
     match_artists_with_wikidata,
 )
 from src.utils.preprocessing_utils import filter_products
+
+ALIAS_MERGE_COLUMNS = [
+    ARTIST_ID_KEY,
+    ARTIST_NAME_KEY,
+    ARTIST_TYPE_KEY,
+    OFFER_CATEGORY_ID_KEY,
+]
 
 
 def get_products_to_remove_and_link_df(
@@ -98,6 +103,64 @@ def get_products_to_remove_and_link_df(
     )
 
     return products_to_remove_df, products_to_link_df
+
+
+def build_artist_alias(
+    product_df: pd.DataFrame,
+    product_artist_link_df: pd.DataFrame,
+    artist_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Combine artist names from artist_df and product_df to create a comprehensive alias dataframe."""
+    artist_alias_from_artist_names_df = (
+        product_artist_link_df.merge(
+            artist_df.assign(
+                artist_name=lambda df: df[ARTIST_NAME_KEY].str.lower()
+            ).loc[:, [ARTIST_ID_KEY, ARTIST_NAME_KEY]],
+            how="left",
+            on=ARTIST_ID_KEY,
+            validate="many_to_one",
+        )
+        .merge(
+            product_df.loc[
+                :, [PRODUCT_ID_KEY, OFFER_CATEGORY_ID_KEY]
+            ].drop_duplicates(),
+            how="left",
+            on=[PRODUCT_ID_KEY],
+            validate="many_to_one",
+        )
+        .loc[:, ALIAS_MERGE_COLUMNS]
+        .drop_duplicates()
+    )
+
+    # Use artist names from products when we have a clear 1:1 mapping between product and artist
+    safe_product_df = product_df.loc[
+        lambda df: ~df.duplicated(subset=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY], keep=False)
+    ]
+    product_with_names_df = product_artist_link_df.merge(
+        safe_product_df,
+        how="inner",
+        left_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
+        right_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
+        validate="many_to_one",
+    )
+    artist_alias_based_on_products_df = (
+        product_with_names_df.loc[:, ALIAS_MERGE_COLUMNS]
+        .drop_duplicates()
+        .sort_values(by=ALIAS_MERGE_COLUMNS)
+    )
+
+    # Combine both sources of artist aliases and remove duplicates
+    return (
+        pd.concat(
+            [
+                artist_alias_from_artist_names_df,
+                artist_alias_based_on_products_df,
+            ],
+            axis=0,
+        )
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
 
 
 def sanity_checks(

--- a/jobs/ml_jobs/artist_linkage/cli/link_new_products_to_artists.py
+++ b/jobs/ml_jobs/artist_linkage/cli/link_new_products_to_artists.py
@@ -20,18 +20,13 @@ from src.constants import (
 )
 from src.utils.loading import load_wikidata
 from src.utils.matching import (
+    ALIAS_MERGE_COLUMNS,
+    build_artist_alias,
     create_artists_tables,
     match_artist_on_offer_names,
     match_artists_with_wikidata,
 )
 from src.utils.preprocessing_utils import filter_products
-
-ALIAS_MERGE_COLUMNS = [
-    ARTIST_ID_KEY,
-    ARTIST_NAME_KEY,
-    ARTIST_TYPE_KEY,
-    OFFER_CATEGORY_ID_KEY,
-]
 
 
 def get_products_to_remove_and_link_df(
@@ -103,64 +98,6 @@ def get_products_to_remove_and_link_df(
     )
 
     return products_to_remove_df, products_to_link_df
-
-
-def build_artist_alias(
-    product_df: pd.DataFrame,
-    product_artist_link_df: pd.DataFrame,
-    artist_df: pd.DataFrame,
-) -> pd.DataFrame:
-    # Combine artist names from both artist_df and product_df to create a comprehensive artist alias dataframe
-    artist_alias_from_artist_names_df = (
-        product_artist_link_df.merge(
-            artist_df.assign(
-                artist_name=lambda df: df[ARTIST_NAME_KEY].str.lower()
-            ).loc[:, [ARTIST_ID_KEY, ARTIST_NAME_KEY]],
-            how="left",
-            on=ARTIST_ID_KEY,
-            validate="many_to_one",
-        )
-        .merge(
-            product_df.loc[
-                :, [PRODUCT_ID_KEY, OFFER_CATEGORY_ID_KEY]
-            ].drop_duplicates(),
-            how="left",
-            on=[PRODUCT_ID_KEY],
-            validate="many_to_one",
-        )
-        .loc[:, ALIAS_MERGE_COLUMNS]
-        .drop_duplicates()
-    )
-
-    # Use artist names from products when we have a clear 1:1 mapping between product and artist (i.e. no duplicates for the same product and artist type)
-    safe_product_df = product_df.loc[
-        lambda df: ~df.duplicated(subset=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY], keep=False)
-    ]
-    product_with_names_df = product_artist_link_df.merge(
-        safe_product_df,
-        how="inner",
-        left_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
-        right_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
-        validate="many_to_one",
-    )
-    artist_alias_based_on_products_df = (
-        product_with_names_df.loc[:, ALIAS_MERGE_COLUMNS]
-        .drop_duplicates()
-        .sort_values(by=ALIAS_MERGE_COLUMNS)
-    )
-
-    # Combine both sources of artist aliases and remove duplicates to create the final artist alias dataframe
-    return (
-        pd.concat(
-            [
-                artist_alias_from_artist_names_df,
-                artist_alias_based_on_products_df,
-            ],
-            axis=0,
-        )
-        .drop_duplicates()
-        .reset_index(drop=True)
-    )
 
 
 def sanity_checks(

--- a/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
+++ b/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
@@ -141,6 +141,7 @@ def match_unmatched_artists_with_wikidata(
 
     Args:
         applicative_artist_df (pd.DataFrame): Current applicative database artists.
+            Must contain ARTIST_PRO_SEARCH_SCORE_KEY column.
         artist_with_wikidata_ids_df (pd.DataFrame): Artists with wikidata_id already assigned.
         product_artist_link_filepath (str): Path to product artist links.
         product_filepath (str): Path to products.
@@ -171,7 +172,7 @@ def match_unmatched_artists_with_wikidata(
     )
 
     aliases_to_match_df = artist_alias_df.merge(
-        artists_without_wiki_ids_df[[ARTIST_ID_KEY]],
+        artists_without_wiki_ids_df[[ARTIST_ID_KEY, ARTIST_PRO_SEARCH_SCORE_KEY]],
         on=ARTIST_ID_KEY,
         how="inner",
     )
@@ -182,7 +183,7 @@ def match_unmatched_artists_with_wikidata(
     if len(preproc_aliases_df) == 0:
         return pd.DataFrame(columns=ARTISTS_KEYS)
 
-    new_artist_clusters_df = (
+    unmatched_artist_clusters_df = (
         preproc_aliases_df.groupby(
             [
                 ARTIST_ID_KEY,
@@ -192,15 +193,22 @@ def match_unmatched_artists_with_wikidata(
             ]
         )
         .agg(
-            tmp_id=(ARTIST_ID_KEY, "first"),
             artist_name_set=(ARTIST_NAME_KEY, lambda x: set(x.unique())),
             artist_name_count=(ARTIST_NAME_KEY, "count"),
             artist_name_nunique=(ARTIST_NAME_KEY, "nunique"),
+            **{
+                ARTIST_PRO_SEARCH_SCORE_KEY: (
+                    ARTIST_PRO_SEARCH_SCORE_KEY,
+                    "first",
+                ),
+            },
         )
         .reset_index()
     )
 
-    matched_df = perform_wikidata_category_matching(new_artist_clusters_df, wiki_df)
+    matched_df = perform_wikidata_category_matching(
+        unmatched_artist_clusters_df, wiki_df
+    )
     if len(matched_df) == 0:
         return pd.DataFrame(columns=ARTISTS_KEYS)
 
@@ -212,29 +220,17 @@ def match_unmatched_artists_with_wikidata(
         lambda df: ~df[WIKIDATA_ID_KEY].isin(already_used_wikidata_ids)
     ]
 
-    # Merge with applicative_artist_df to get artist_pro_search_score
-    matched_df = matched_df.merge(
-        applicative_artist_df[[ARTIST_ID_KEY, ARTIST_PRO_SEARCH_SCORE_KEY]],
-        left_on="tmp_id",
-        right_on=ARTIST_ID_KEY,
-        how="left",
-    ).assign(
-        **{
-            ARTIST_PRO_SEARCH_SCORE_KEY: lambda df: df[
-                ARTIST_PRO_SEARCH_SCORE_KEY
-            ].fillna(0)
-        }
-    )
-
-    # Constraint 2: if a wikidata_id is matched to multiple artist_ids,
-    # keep the match for the artist with the highest pro search score
+    # Sort for Contraint 2 and 3
     matched_df = matched_df.sort_values(
         by=[ARTIST_PRO_SEARCH_SCORE_KEY, "matching_score", "gkg"],
         ascending=False,
-    ).drop_duplicates(subset=[WIKIDATA_ID_KEY], keep="first")
+    )
+    # Constraint 2: if a wikidata_id is matched to multiple artist_ids, keep
+    # the match for the artist with the highest pro search score
+    matched_df = matched_df.drop_duplicates(subset=[WIKIDATA_ID_KEY], keep="first")
 
-    # Constraint 3: keep the best match per artist_id (tmp_id)
-    matched_df = matched_df.drop_duplicates(subset=["tmp_id"], keep="first")
+    # Constraint 3: keep the best match per artist_id
+    matched_df = matched_df.drop_duplicates(subset=[ARTIST_ID_KEY], keep="first")
 
     if len(matched_df) == 0:
         return pd.DataFrame(columns=ARTISTS_KEYS)
@@ -242,13 +238,16 @@ def match_unmatched_artists_with_wikidata(
     logger.info(
         f"Successfully matched {len(matched_df)} unmatched artists to Wikidata."
     )
-    new_matched_df = matched_df.assign(
-        artist_id=lambda df: df.tmp_id,
-        artist_name=lambda df: df.wiki_artist_name.fillna(df[ARTIST_NAME_TO_MATCH_KEY])
-        .astype(str)
-        .apply(lambda s: s.title()),
+    matched_artists_df = matched_df.assign(
+        **{
+            ARTIST_NAME_KEY: lambda df: (
+                df.wiki_artist_name.fillna(df[ARTIST_NAME_TO_MATCH_KEY])
+                .astype(str)
+                .apply(lambda s: s.title())
+            ),
+        }
     )
-    return new_matched_df.loc[:, ARTISTS_KEYS]
+    return matched_artists_df.loc[:, ARTISTS_KEYS]
 
 
 def sanity_checks(

--- a/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
+++ b/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
@@ -10,23 +10,25 @@ from src.constants import (
     ARTIST_DESCRIPTION_KEY,
     ARTIST_ID_KEY,
     ARTIST_NAME_KEY,
+    ARTIST_NAME_TO_MATCH_KEY,
+    ARTIST_PRO_SEARCH_SCORE_KEY,
     ARTIST_TYPE_KEY,
     ARTIST_WIKI_ID_KEY,
     ARTISTS_KEYS,
     COMMENT_KEY,
     IMG_KEY,
     OFFER_CATEGORY_ID_KEY,
+    PRODUCT_ID_KEY,
     PRODUCTS_KEYS,
     WIKIDATA_ID_KEY,
+    Action,
 )
 from src.utils.loading import load_wikidata
-
-ALIAS_MERGE_COLUMNS = [
-    ARTIST_ID_KEY,
-    ARTIST_NAME_KEY,
-    ARTIST_TYPE_KEY,
-    OFFER_CATEGORY_ID_KEY,
-]
+from src.utils.matching import build_artist_alias, perform_wikidata_category_matching
+from src.utils.preprocessing_utils import (
+    filter_products,
+    prepare_artist_names_for_matching,
+)
 
 
 def retrieve_artist_wikidata_id(
@@ -80,6 +82,7 @@ def retrieve_artist_wikidata_id(
 
 def create_delta_df_for_metadata_refresh(
     refreshed_artists_df: pd.DataFrame,
+    newly_matched_artists_df: pd.DataFrame,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Create delta dataframes for metadata refresh operation.
 
@@ -90,6 +93,8 @@ def create_delta_df_for_metadata_refresh(
     Args:
         refreshed_artists_df (pd.DataFrame): Dataframe containing artists with
             refreshed metadata from wikidata.
+        newly_matched_artists_df (pd.DataFrame): Dataframe containing newly matched
+            artists with metadata from wikidata.
 
     Returns:
         tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]: A tuple containing:
@@ -97,11 +102,20 @@ def create_delta_df_for_metadata_refresh(
             - delta_artist_df: Dataframe with artists to update and metadata
             - empty_delta_artist_alias_df: Empty dataframe for artist aliases
     """
-    delta_artist_df = refreshed_artists_df.loc[:, ARTISTS_KEYS].assign(
+    delta_already_matched = refreshed_artists_df.loc[:, ARTISTS_KEYS].assign(
         **{
-            ACTION_KEY: "update",
+            ACTION_KEY: Action.update,
             COMMENT_KEY: "artist with refreshed metadata from wikidata",
         }
+    )
+    delta_newly_matched = newly_matched_artists_df.assign(
+        **{
+            ACTION_KEY: Action.update,
+            COMMENT_KEY: "artist matched and refreshed from wikidata",
+        }
+    )
+    delta_artist_df = pd.concat(
+        [delta_already_matched, delta_newly_matched], ignore_index=True
     )
     empty_delta_product_artist_link_df = pd.DataFrame(
         columns=[*PRODUCTS_KEYS, ACTION_KEY, COMMENT_KEY]
@@ -114,6 +128,127 @@ def create_delta_df_for_metadata_refresh(
         delta_artist_df,
         empty_delta_artist_alias_df,
     )
+
+
+def match_unmatched_artists_with_wikidata(
+    applicative_artist_df: pd.DataFrame,
+    artist_with_wikidata_ids_df: pd.DataFrame,
+    product_artist_link_filepath: str,
+    product_filepath: str,
+    wiki_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Match unmatched existing artists onto Wikidata.
+
+    Args:
+        applicative_artist_df (pd.DataFrame): Current applicative database artists.
+        artist_with_wikidata_ids_df (pd.DataFrame): Artists with wikidata_id already assigned.
+        product_artist_link_filepath (str): Path to product artist links.
+        product_filepath (str): Path to products.
+        wiki_df (pd.DataFrame): Wikidata dump.
+
+    Returns:
+        pd.DataFrame: Newly matched artists to update, projected to ARTISTS_KEYS.
+    """
+    artists_without_wiki_ids_df = applicative_artist_df.loc[
+        lambda df: df[WIKIDATA_ID_KEY].isna()
+    ]
+    if len(artists_without_wiki_ids_df) == 0:
+        return pd.DataFrame(columns=ARTISTS_KEYS)
+
+    product_artist_link_df = pd.read_parquet(product_artist_link_filepath).astype(
+        {PRODUCT_ID_KEY: int}
+    )
+    product_df = (
+        pd.read_parquet(product_filepath)
+        .astype({PRODUCT_ID_KEY: int})
+        .pipe(filter_products)
+    )
+
+    artist_alias_df = build_artist_alias(
+        product_df=product_df,
+        product_artist_link_df=product_artist_link_df,
+        artist_df=applicative_artist_df,
+    )
+
+    aliases_to_match_df = artist_alias_df.merge(
+        artists_without_wiki_ids_df[[ARTIST_ID_KEY]],
+        on=ARTIST_ID_KEY,
+        how="inner",
+    )
+    if len(aliases_to_match_df) == 0:
+        return pd.DataFrame(columns=ARTISTS_KEYS)
+
+    preproc_aliases_df = prepare_artist_names_for_matching(aliases_to_match_df)
+    if len(preproc_aliases_df) == 0:
+        return pd.DataFrame(columns=ARTISTS_KEYS)
+
+    new_artist_clusters_df = (
+        preproc_aliases_df.groupby(
+            [
+                ARTIST_ID_KEY,
+                OFFER_CATEGORY_ID_KEY,
+                ARTIST_TYPE_KEY,
+                ARTIST_NAME_TO_MATCH_KEY,
+            ]
+        )
+        .agg(
+            tmp_id=(ARTIST_ID_KEY, "first"),
+            artist_name_set=(ARTIST_NAME_KEY, lambda x: set(x.unique())),
+            artist_name_count=(ARTIST_NAME_KEY, "count"),
+            artist_name_nunique=(ARTIST_NAME_KEY, "nunique"),
+        )
+        .reset_index()
+    )
+
+    matched_df = perform_wikidata_category_matching(new_artist_clusters_df, wiki_df)
+    if len(matched_df) == 0:
+        return pd.DataFrame(columns=ARTISTS_KEYS)
+
+    # Constraint 1: exclude wikidata_ids already used in the database
+    already_used_wikidata_ids = set(
+        artist_with_wikidata_ids_df[WIKIDATA_ID_KEY].dropna().unique()
+    )
+    matched_df = matched_df.loc[
+        lambda df: ~df[WIKIDATA_ID_KEY].isin(already_used_wikidata_ids)
+    ]
+
+    # Merge with applicative_artist_df to get artist_pro_search_score
+    matched_df = matched_df.merge(
+        applicative_artist_df[[ARTIST_ID_KEY, ARTIST_PRO_SEARCH_SCORE_KEY]],
+        left_on="tmp_id",
+        right_on=ARTIST_ID_KEY,
+        how="left",
+    ).assign(
+        **{
+            ARTIST_PRO_SEARCH_SCORE_KEY: lambda df: df[
+                ARTIST_PRO_SEARCH_SCORE_KEY
+            ].fillna(0)
+        }
+    )
+
+    # Constraint 2: if a wikidata_id is matched to multiple artist_ids,
+    # keep the match for the artist with the highest pro search score
+    matched_df = matched_df.sort_values(
+        by=[ARTIST_PRO_SEARCH_SCORE_KEY, "matching_score", "gkg"],
+        ascending=False,
+    ).drop_duplicates(subset=[WIKIDATA_ID_KEY], keep="first")
+
+    # Constraint 3: keep the best match per artist_id (tmp_id)
+    matched_df = matched_df.drop_duplicates(subset=["tmp_id"], keep="first")
+
+    if len(matched_df) == 0:
+        return pd.DataFrame(columns=ARTISTS_KEYS)
+
+    logger.info(
+        f"Successfully matched {len(matched_df)} unmatched artists to Wikidata."
+    )
+    new_matched_df = matched_df.assign(
+        artist_id=lambda df: df.tmp_id,
+        artist_name=lambda df: df.wiki_artist_name.fillna(df[ARTIST_NAME_TO_MATCH_KEY])
+        .astype(str)
+        .apply(lambda s: s.title()),
+    )
+    return new_matched_df.loc[:, ARTISTS_KEYS]
 
 
 def sanity_checks(
@@ -201,6 +336,8 @@ app = typer.Typer()
 def main(
     # Input files
     artist_file_path: str = typer.Option(),
+    product_artist_link_filepath: str = typer.Option(),
+    product_filepath: str = typer.Option(),
     wiki_base_path: str = typer.Option(),
     wiki_file_name: str = typer.Option(),
     # Output files
@@ -213,14 +350,16 @@ def main(
     This function orchestrates the complete metadata refresh process:
     1. Loads artist, artist alias, and wikidata files
     2. Retrieves wikidata IDs for existing artists
-    3. Matches artists with wikidata to refresh metadata
-    4. Creates delta dataframes for the update operation
-    5. Performs sanity checks to ensure data quality
-    6. Saves the delta dataframes for downstream processing
+    3. Matches unmatched artists with wikidata to find new matches
+    4. Matches artists with wikidata to refresh metadata
+    5. Creates delta dataframes for the update operation
+    6. Performs sanity checks to ensure data quality
+    7. Saves the delta dataframes for downstream processing
 
     Args:
         artist_file_path (str): Path to the parquet file containing artist data.
-        artist_alias_file_path (str): Path to the parquet file containing artist aliases.
+        product_artist_link_filepath (str): Optional path to product artist link parquet file.
+        product_filepath (str): Optional path to products parquet file.
         wiki_base_path (str): Base path for wikidata files.
         wiki_file_name (str): Name of the wikidata file to load.
         output_delta_artist_file_path (str): Output path for delta artist dataframe.
@@ -249,7 +388,7 @@ def main(
         f"Number of artists: {len(applicative_artist_df)}, Number of artists with wikidata ids: {len(artist_with_wikidata_ids_df)}, Number of wikidata entries: {len(wiki_df)}"
     )
 
-    # 2. Match on wikidata to have fresh metadatas
+    # 2. Match on wikidata to have fresh metadatas for already matched artists
     logger.info("Refreshing artist metadatas from wikidata...")
     refreshed_artists_df = artist_with_wikidata_ids_df.merge(
         wiki_df.drop(columns=["alias", "raw_alias"]).drop_duplicates(),
@@ -258,7 +397,16 @@ def main(
         suffixes=("_old", ""),
     )
 
-    # 3. Refresh statistics
+    # 3. Match existing unmatched artists on Wikidata
+    newly_matched_artists_df = match_unmatched_artists_with_wikidata(
+        applicative_artist_df=applicative_artist_df,
+        artist_with_wikidata_ids_df=artist_with_wikidata_ids_df,
+        product_artist_link_filepath=product_artist_link_filepath,
+        product_filepath=product_filepath,
+        wiki_df=wiki_df,
+    )
+
+    # 4. Refresh statistics
     artists_with_wiki_id = artist_with_wikidata_ids_df[WIKIDATA_ID_KEY].notna().sum()
     artists_matched_in_wiki = refreshed_artists_df[ARTIST_NAME_KEY].notna().sum()
     artists_with_wiki_id_no_match = artists_with_wiki_id - artists_matched_in_wiki
@@ -271,20 +419,22 @@ def main(
 
     # 5. Build delta artist dataframe
     logger.info("Building delta artist dataframe...")
-    empty_delta_product_artist_link_df, delta_artist_df, empty_delta_artist_alias_df = (
+    delta_product_df, delta_artist_df, delta_artist_alias_df = (
         create_delta_df_for_metadata_refresh(
             refreshed_artists_df=refreshed_artists_df,
+            newly_matched_artists_df=newly_matched_artists_df,
         )
     )
+
     logger.success("Delta artist dataframe built successfully.")
     logger.info(f"Number of artists to update: {len(delta_artist_df)}")
 
     # 6. Sanity check for consistency
     logger.info("Performing sanity checks...")
     sanity_checks(
-        delta_product_df=empty_delta_product_artist_link_df,
+        delta_product_df=delta_product_df,
         delta_artist_df=delta_artist_df,
-        delta_artist_alias_df=empty_delta_artist_alias_df,
+        delta_artist_alias_df=delta_artist_alias_df,
         applicative_artist_df=applicative_artist_df,
     )
     logger.success("Sanity checks passed successfully.")
@@ -295,13 +445,8 @@ def main(
         f"Saving delta artist dataframes to {output_delta_artist_file_path}, {output_delta_artist_alias_file_path} and {output_delta_product_artist_link_file_path}."
     )
     delta_artist_df.to_parquet(output_delta_artist_file_path, index=False)
-    empty_delta_product_artist_link_df.to_parquet(
-        output_delta_product_artist_link_file_path, index=False
-    )
-    # TODO: Remove artist alias output when not needed by backend ingestion
-    empty_delta_artist_alias_df.to_parquet(
-        output_delta_artist_alias_file_path, index=False
-    )
+    delta_product_df.to_parquet(output_delta_product_artist_link_file_path, index=False)
+    delta_artist_alias_df.to_parquet(output_delta_artist_alias_file_path, index=False)
     logger.success("Delta dataframes saved successfully.")
 
 

--- a/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
+++ b/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
@@ -208,7 +208,7 @@ def match_unmatched_artists_with_wikidata(
 
     matched_df = perform_wikidata_category_matching(
         unmatched_artist_clusters_df, wiki_df
-    )
+    ).loc[lambda df: df[WIKIDATA_ID_KEY].notna()]
     if len(matched_df) == 0:
         return pd.DataFrame(columns=ARTISTS_KEYS)
 

--- a/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
+++ b/jobs/ml_jobs/artist_linkage/cli/refresh_artist_metadatas.py
@@ -24,7 +24,7 @@ from src.constants import (
     Action,
 )
 from src.utils.loading import load_wikidata
-from src.utils.matching import build_artist_alias, perform_wikidata_category_matching
+from src.utils.matching import perform_wikidata_category_matching
 from src.utils.preprocessing_utils import (
     filter_products,
     prepare_artist_names_for_matching,
@@ -156,6 +156,7 @@ def match_unmatched_artists_with_wikidata(
     if len(artists_without_wiki_ids_df) == 0:
         return pd.DataFrame(columns=ARTISTS_KEYS)
 
+    # Derive (artist_id → offer_category_id, artist_type) from product/link data
     product_artist_link_df = pd.read_parquet(product_artist_link_filepath).astype(
         {PRODUCT_ID_KEY: int}
     )
@@ -164,46 +165,43 @@ def match_unmatched_artists_with_wikidata(
         .astype({PRODUCT_ID_KEY: int})
         .pipe(filter_products)
     )
-
-    artist_alias_df = build_artist_alias(
-        product_df=product_df,
-        product_artist_link_df=product_artist_link_df,
-        artist_df=applicative_artist_df,
+    artist_category_type_df = (
+        product_artist_link_df.merge(
+            product_df[[PRODUCT_ID_KEY, OFFER_CATEGORY_ID_KEY]].drop_duplicates(),
+            on=PRODUCT_ID_KEY,
+            how="inner",
+        )
+        .loc[:, [ARTIST_ID_KEY, ARTIST_TYPE_KEY, OFFER_CATEGORY_ID_KEY]]
+        .drop_duplicates()
     )
 
-    aliases_to_match_df = artist_alias_df.merge(
-        artists_without_wiki_ids_df[[ARTIST_ID_KEY, ARTIST_PRO_SEARCH_SCORE_KEY]],
+    # Enrich unmatched artists with offer_category and artist_type
+    artists_to_match_df = artists_without_wiki_ids_df[
+        [ARTIST_ID_KEY, ARTIST_NAME_KEY, ARTIST_PRO_SEARCH_SCORE_KEY]
+    ].merge(
+        artist_category_type_df,
         on=ARTIST_ID_KEY,
         how="inner",
     )
-    if len(aliases_to_match_df) == 0:
+
+    # Preprocess the actual artist name for wikidata matching
+    preproc_artists_df = prepare_artist_names_for_matching(artists_to_match_df)
+    if len(preproc_artists_df) == 0:
         return pd.DataFrame(columns=ARTISTS_KEYS)
 
-    preproc_aliases_df = prepare_artist_names_for_matching(aliases_to_match_df)
-    if len(preproc_aliases_df) == 0:
-        return pd.DataFrame(columns=ARTISTS_KEYS)
-
-    unmatched_artist_clusters_df = (
-        preproc_aliases_df.groupby(
-            [
-                ARTIST_ID_KEY,
-                OFFER_CATEGORY_ID_KEY,
-                ARTIST_TYPE_KEY,
-                ARTIST_NAME_TO_MATCH_KEY,
-            ]
-        )
-        .agg(
-            artist_name_set=(ARTIST_NAME_KEY, lambda x: set(x.unique())),
-            artist_name_count=(ARTIST_NAME_KEY, "count"),
-            artist_name_nunique=(ARTIST_NAME_KEY, "nunique"),
-            **{
-                ARTIST_PRO_SEARCH_SCORE_KEY: (
-                    ARTIST_PRO_SEARCH_SCORE_KEY,
-                    "first",
-                ),
-            },
-        )
-        .reset_index()
+    unmatched_artist_clusters_df = preproc_artists_df.drop_duplicates(
+        subset=[
+            ARTIST_ID_KEY,
+            OFFER_CATEGORY_ID_KEY,
+            ARTIST_TYPE_KEY,
+            ARTIST_NAME_TO_MATCH_KEY,
+        ]
+    ).assign(
+        artist_name_set=lambda df: df[ARTIST_NAME_KEY].apply(
+            lambda x: {x}
+        ),  # for perform_wikidata_category_matching compatibility
+        artist_name_count=1,
+        artist_name_nunique=1,
     )
 
     matched_df = perform_wikidata_category_matching(
@@ -225,6 +223,7 @@ def match_unmatched_artists_with_wikidata(
         by=[ARTIST_PRO_SEARCH_SCORE_KEY, "matching_score", "gkg"],
         ascending=False,
     )
+
     # Constraint 2: if a wikidata_id is matched to multiple artist_ids, keep
     # the match for the artist with the highest pro search score
     matched_df = matched_df.drop_duplicates(subset=[WIKIDATA_ID_KEY], keep="first")

--- a/jobs/ml_jobs/artist_linkage/src/constants.py
+++ b/jobs/ml_jobs/artist_linkage/src/constants.py
@@ -48,6 +48,8 @@ ARTIST_MEDIATION_UUID_KEY = "artist_mediation_uuid"
 ARTIST_BIOGRAPHY_KEY = "artist_biography"
 ARTIST_WIKI_ID_KEY = "artist_wiki_id"
 ARTIST_APP_SEARCH_SCORE_KEY = "artist_app_search_score"
+ARTIST_PRO_SEARCH_SCORE_KEY = "artist_pro_search_score"
+
 
 ID_PER_CATEGORY = "id_per_category"
 TOTAL_BOOKING_COUNT = "total_booking_count"

--- a/jobs/ml_jobs/artist_linkage/src/utils/matching.py
+++ b/jobs/ml_jobs/artist_linkage/src/utils/matching.py
@@ -17,7 +17,6 @@ from src.constants import (
     IMG_KEY,
     OFFER_CATEGORY_ID_KEY,
     POSTPROCESSED_ARTIST_NAME_KEY,
-    PRODUCT_ID_KEY,
     PRODUCTS_KEYS,
     WIKIDATA_ID_KEY,
     Action,
@@ -461,70 +460,3 @@ def match_namesakes_per_category(
             )
         )
     return pd.concat(matched_df_list)
-
-
-ALIAS_MERGE_COLUMNS = [
-    ARTIST_ID_KEY,
-    ARTIST_NAME_KEY,
-    ARTIST_TYPE_KEY,
-    OFFER_CATEGORY_ID_KEY,
-]
-
-
-def build_artist_alias(
-    product_df: pd.DataFrame,
-    product_artist_link_df: pd.DataFrame,
-    artist_df: pd.DataFrame,
-) -> pd.DataFrame:
-    """Combine artist names from artist_df and product_df to create a comprehensive alias dataframe."""
-    # Combine artist names from both artist_df and product_df to create a comprehensive artist alias dataframe
-    artist_alias_from_artist_names_df = (
-        product_artist_link_df.merge(
-            artist_df.assign(
-                artist_name=lambda df: df[ARTIST_NAME_KEY].str.lower()
-            ).loc[:, [ARTIST_ID_KEY, ARTIST_NAME_KEY]],
-            how="left",
-            on=ARTIST_ID_KEY,
-            validate="many_to_one",
-        )
-        .merge(
-            product_df.loc[
-                :, [PRODUCT_ID_KEY, OFFER_CATEGORY_ID_KEY]
-            ].drop_duplicates(),
-            how="left",
-            on=[PRODUCT_ID_KEY],
-            validate="many_to_one",
-        )
-        .loc[:, ALIAS_MERGE_COLUMNS]
-        .drop_duplicates()
-    )
-
-    # Use artist names from products when we have a clear 1:1 mapping between product and artist
-    safe_product_df = product_df.loc[
-        lambda df: ~df.duplicated(subset=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY], keep=False)
-    ]
-    product_with_names_df = product_artist_link_df.merge(
-        safe_product_df,
-        how="inner",
-        left_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
-        right_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
-        validate="many_to_one",
-    )
-    artist_alias_based_on_products_df = (
-        product_with_names_df.loc[:, ALIAS_MERGE_COLUMNS]
-        .drop_duplicates()
-        .sort_values(by=ALIAS_MERGE_COLUMNS)
-    )
-
-    # Combine both sources of artist aliases and remove duplicates
-    return (
-        pd.concat(
-            [
-                artist_alias_from_artist_names_df,
-                artist_alias_based_on_products_df,
-            ],
-            axis=0,
-        )
-        .drop_duplicates()
-        .reset_index(drop=True)
-    )

--- a/jobs/ml_jobs/artist_linkage/src/utils/matching.py
+++ b/jobs/ml_jobs/artist_linkage/src/utils/matching.py
@@ -238,7 +238,8 @@ def perform_wikidata_category_matching(
             Must contain 'artist_name', 'raw_alias', and category indicator columns.
 
     Returns:
-        pd.DataFrame: DataFrame containing all matched artists before remapping/deduplication.
+        pd.DataFrame: DataFrame containing all artist clusters after category matching,
+            including unmatched clusters (with NaN wikidata_id).
     """
     # 1. Preprocess to use wikidata matching functions
     wiki_df = (
@@ -279,7 +280,7 @@ def perform_wikidata_category_matching(
         [matched_without_namesake_df, matched_namesakes_df]
     ).reset_index(drop=True)
 
-    return matched_df.loc[lambda df: df[WIKIDATA_ID_KEY].notna()]
+    return matched_df
 
 
 def match_artists_with_wikidata(

--- a/jobs/ml_jobs/artist_linkage/src/utils/matching.py
+++ b/jobs/ml_jobs/artist_linkage/src/utils/matching.py
@@ -267,7 +267,11 @@ def perform_wikidata_category_matching(
     matched_without_namesake_df = (
         match_per_category_no_namesakes(new_artist_clusters_df, wiki_df)
         .assign(has_namesake=False)
-        .loc[lambda df: ~df.tmp_id.isin(matched_namesakes_df.tmp_id.unique())]
+        .loc[
+            lambda df: ~df[ARTIST_ID_KEY].isin(
+                matched_namesakes_df[ARTIST_ID_KEY].unique()
+            )
+        ]
     )
 
     # 3. Reconciliate matching
@@ -340,9 +344,11 @@ def match_artists_with_wikidata(
 
     # 5. Remap matched_df with wiki_to_artist_mapping
     matched_with_ids_df = matched_df.assign(
-        artist_id=lambda df: df[WIKIDATA_ID_KEY]
-        .map(wiki_to_artist_mapping)
-        .fillna(df.tmp_id),
+        **{
+            ARTIST_ID_KEY: lambda df: df[WIKIDATA_ID_KEY]
+            .map(wiki_to_artist_mapping)
+            .fillna(df[ARTIST_ID_KEY]),
+        },
         postprocessed_artist_name=lambda df: df.wiki_artist_name.fillna(
             df[ARTIST_NAME_TO_MATCH_KEY]
         ).apply(lambda s: s.title()),

--- a/jobs/ml_jobs/artist_linkage/src/utils/matching.py
+++ b/jobs/ml_jobs/artist_linkage/src/utils/matching.py
@@ -17,6 +17,7 @@ from src.constants import (
     IMG_KEY,
     OFFER_CATEGORY_ID_KEY,
     POSTPROCESSED_ARTIST_NAME_KEY,
+    PRODUCT_ID_KEY,
     PRODUCTS_KEYS,
     WIKIDATA_ID_KEY,
     Action,
@@ -223,6 +224,60 @@ def create_artists_tables(
     )
 
 
+def perform_wikidata_category_matching(
+    new_artist_clusters_df: pd.DataFrame,
+    wiki_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Performs category and namesake-based matching of artist clusters against Wikidata.
+
+    Args:
+        new_artist_clusters_df (pd.DataFrame): DataFrame containing artist clusters
+            with artist names to be matched. Must contain ARTIST_NAME_TO_MATCH_KEY column.
+        wiki_df (pd.DataFrame): DataFrame containing Wikidata information.
+            Must contain 'artist_name', 'raw_alias', and category indicator columns.
+
+    Returns:
+        pd.DataFrame: DataFrame containing all matched artists before remapping/deduplication.
+    """
+    # 1. Preprocess to use wikidata matching functions
+    wiki_df = (
+        wiki_df.rename(
+            columns={
+                "artist_name": "wiki_artist_name",
+            }
+        )
+        .assign(
+            alias_name_to_match=lambda df: df.raw_alias.apply(extract_artist_name),
+            alias=lambda df: df.alias_name_to_match,
+        )
+        .loc[lambda df: (df.alias_name_to_match != "") & df.alias_name_to_match.notna()]
+    )
+    new_artist_clusters_df = new_artist_clusters_df.assign(
+        alias=lambda df: df[ARTIST_NAME_TO_MATCH_KEY]
+    )
+    matched_namesakes_df = (
+        match_namesakes_per_category(new_artist_clusters_df, wiki_df)
+        .loc[lambda df: df[WIKIDATA_ID_KEY].notna()]
+        .assign(has_namesake=True)
+    )
+
+    # 2. Match artists on wikidata for artists with no namesake
+    logger.info(f"Matching {len(new_artist_clusters_df)} artists with Wikidata...")
+    matched_without_namesake_df = (
+        match_per_category_no_namesakes(new_artist_clusters_df, wiki_df)
+        .assign(has_namesake=False)
+        .loc[lambda df: ~df.tmp_id.isin(matched_namesakes_df.tmp_id.unique())]
+    )
+
+    # 3. Reconciliate matching
+    matched_df = pd.concat(
+        [matched_without_namesake_df, matched_namesakes_df]
+    ).reset_index(drop=True)
+
+    return matched_df.loc[lambda df: df[WIKIDATA_ID_KEY].notna()]
+
+
 def match_artists_with_wikidata(
     new_artist_clusters_df: pd.DataFrame,
     wiki_df: pd.DataFrame,
@@ -259,40 +314,8 @@ def match_artists_with_wikidata(
         artist_with_wiki_ids_df = pd.DataFrame(
             columns=[ARTIST_ID_KEY, ARTIST_WIKI_ID_KEY]
         )
-    # 1. Preprocess to use wikidata matching functions
-    wiki_df = (
-        wiki_df.rename(
-            columns={
-                "artist_name": "wiki_artist_name",
-            }
-        )
-        .assign(
-            alias_name_to_match=lambda df: df.raw_alias.apply(extract_artist_name),
-            alias=lambda df: df.alias_name_to_match,
-        )
-        .loc[lambda df: (df.alias_name_to_match != "") & df.alias_name_to_match.notna()]
-    )
-    new_artist_clusters_df = new_artist_clusters_df.assign(
-        alias=lambda df: df[ARTIST_NAME_TO_MATCH_KEY]
-    )
-    matched_namesakes_df = (
-        match_namesakes_per_category(new_artist_clusters_df, wiki_df)
-        .loc[lambda df: df[WIKIDATA_ID_KEY].notna()]
-        .assign(has_namesake=True)
-    )
 
-    # 2. Match artists on wikidata for artists with no namesake
-    logger.info(f"Matching {len(new_artist_clusters_df)} artists with Wikidata...")
-    matched_without_namesake_df = (
-        match_per_category_no_namesakes(new_artist_clusters_df, wiki_df)
-        .assign(has_namesake=False)
-        .loc[lambda df: ~df.tmp_id.isin(matched_namesakes_df.tmp_id.unique())]
-    )
-
-    # 3. Reconciliate matching
-    matched_df = pd.concat(
-        [matched_without_namesake_df, matched_namesakes_df]
-    ).reset_index(drop=True)
+    matched_df = perform_wikidata_category_matching(new_artist_clusters_df, wiki_df)
 
     # 4. wikidata_id to artist_id mapping
     new_mapping_df = (
@@ -431,3 +454,70 @@ def match_namesakes_per_category(
             )
         )
     return pd.concat(matched_df_list)
+
+
+ALIAS_MERGE_COLUMNS = [
+    ARTIST_ID_KEY,
+    ARTIST_NAME_KEY,
+    ARTIST_TYPE_KEY,
+    OFFER_CATEGORY_ID_KEY,
+]
+
+
+def build_artist_alias(
+    product_df: pd.DataFrame,
+    product_artist_link_df: pd.DataFrame,
+    artist_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Combine artist names from artist_df and product_df to create a comprehensive alias dataframe."""
+    # Combine artist names from both artist_df and product_df to create a comprehensive artist alias dataframe
+    artist_alias_from_artist_names_df = (
+        product_artist_link_df.merge(
+            artist_df.assign(
+                artist_name=lambda df: df[ARTIST_NAME_KEY].str.lower()
+            ).loc[:, [ARTIST_ID_KEY, ARTIST_NAME_KEY]],
+            how="left",
+            on=ARTIST_ID_KEY,
+            validate="many_to_one",
+        )
+        .merge(
+            product_df.loc[
+                :, [PRODUCT_ID_KEY, OFFER_CATEGORY_ID_KEY]
+            ].drop_duplicates(),
+            how="left",
+            on=[PRODUCT_ID_KEY],
+            validate="many_to_one",
+        )
+        .loc[:, ALIAS_MERGE_COLUMNS]
+        .drop_duplicates()
+    )
+
+    # Use artist names from products when we have a clear 1:1 mapping between product and artist
+    safe_product_df = product_df.loc[
+        lambda df: ~df.duplicated(subset=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY], keep=False)
+    ]
+    product_with_names_df = product_artist_link_df.merge(
+        safe_product_df,
+        how="inner",
+        left_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
+        right_on=[PRODUCT_ID_KEY, ARTIST_TYPE_KEY],
+        validate="many_to_one",
+    )
+    artist_alias_based_on_products_df = (
+        product_with_names_df.loc[:, ALIAS_MERGE_COLUMNS]
+        .drop_duplicates()
+        .sort_values(by=ALIAS_MERGE_COLUMNS)
+    )
+
+    # Combine both sources of artist aliases and remove duplicates
+    return (
+        pd.concat(
+            [
+                artist_alias_from_artist_names_df,
+                artist_alias_based_on_products_df,
+            ],
+            axis=0,
+        )
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )

--- a/jobs/ml_jobs/artist_linkage/tests/link_new_products_to_artists_test.py
+++ b/jobs/ml_jobs/artist_linkage/tests/link_new_products_to_artists_test.py
@@ -1,0 +1,135 @@
+import os
+from unittest.mock import patch
+
+import pandas as pd
+
+from cli.link_new_products_to_artists import main
+from src.constants import (
+    ARTIST_DESCRIPTION_KEY,
+    ARTIST_ID_KEY,
+    ARTIST_NAME_KEY,
+    WIKIDATA_ID_KEY,
+    WIKIPEDIA_URL_KEY,
+)
+
+
+def test_link_new_products_to_artists(tmp_path):
+    # 1. Setup mock data files
+    artist_file = tmp_path / "applicative_artist.parquet"
+    product_artist_link_file = tmp_path / "product_artist_link.parquet"
+    product_file = tmp_path / "product.parquet"
+
+    output_delta_artist = tmp_path / "delta_artist.parquet"
+    output_delta_artist_alias = tmp_path / "delta_artist_alias.parquet"
+    output_delta_product_link = tmp_path / "delta_product_link.parquet"
+
+    # Existing database artist:
+    # id1 is already matched to Q1
+    artist_data = {
+        ARTIST_ID_KEY: ["id1"],
+        ARTIST_NAME_KEY: ["Artist One"],
+        ARTIST_DESCRIPTION_KEY: ["Description One"],
+        "wikidata_image_file_url": [None],
+        WIKIDATA_ID_KEY: ["Q1"],
+        WIKIPEDIA_URL_KEY: [None],
+    }
+    pd.DataFrame(artist_data).to_parquet(artist_file, index=False)
+
+    # Current links: product 1 linked to id1
+    link_data = {
+        "offer_product_id": [1],
+        ARTIST_ID_KEY: ["id1"],
+        "artist_type": ["music"],
+    }
+    pd.DataFrame(link_data).to_parquet(product_artist_link_file, index=False)
+
+    # Products:
+    # Product 1: already linked
+    # Product 2: new product (Ed Sheeran), matches Wikidata Q2
+    # Product 3: new product (Unknown Band), does not match Wikidata
+    product_data = {
+        "offer_product_id": [1, 2, 3],
+        ARTIST_NAME_KEY: ["Artist One", "Ed Sheeran", "Unknown Band"],
+        "artist_type": ["music", "music", "music"],
+        "offer_category_id": ["SPECTACLE", "SPECTACLE", "SPECTACLE"],
+    }
+    pd.DataFrame(product_data).to_parquet(product_file, index=False)
+
+    # Wikidata dump:
+    # Q1: Artist One
+    # Q2: Ed Sheeran
+    wiki_data = {
+        WIKIDATA_ID_KEY: ["Q1", "Q2"],
+        "artist_name": ["Artist One", "Ed Sheeran"],
+        "alias": ["Artist One", "Ed Sheeran"],
+        "raw_alias": ["Artist One", "Ed Sheeran"],
+        "matching_score": [1.0, 1.0],
+        "gkg": [100, 200],
+        "music": [True, True],
+        "book": [False, False],
+        "movie": [False, False],
+        ARTIST_DESCRIPTION_KEY: [
+            "Description One",
+            "English singer-songwriter",
+        ],
+        "img": ["img1.jpg", "img2.jpg"],
+        WIKIPEDIA_URL_KEY: [
+            "https://wikipedia.org/wiki/Artist_One",
+            "https://wikipedia.org/wiki/Ed_Sheeran",
+        ],
+    }
+
+    # Run in dev environment
+    os.environ["ENV_SHORT_NAME"] = "dev"
+
+    with patch("cli.link_new_products_to_artists.load_wikidata") as mock_load:
+        mock_load.return_value = pd.DataFrame(wiki_data)
+
+        main(
+            artist_filepath=str(artist_file),
+            product_artist_link_filepath=str(product_artist_link_file),
+            product_filepath=str(product_file),
+            wiki_base_path=str(tmp_path),
+            wiki_file_name="wiki.parquet",
+            output_delta_artist_file_path=str(output_delta_artist),
+            output_delta_artist_alias_file_path=str(output_delta_artist_alias),
+            output_delta_product_artist_link_filepath=str(output_delta_product_link),
+        )
+
+    # 4. Load outputs and verify
+    delta_artist_df = pd.read_parquet(output_delta_artist)
+    delta_artist_alias_df = pd.read_parquet(output_delta_artist_alias)
+    delta_product_link_df = pd.read_parquet(output_delta_product_link)
+
+    # Verify artist aliases:
+    assert len(delta_artist_alias_df) >= 2
+
+    # Verify products:
+    # 2 new products should be in delta_product_link_df (product 2 and product 3)
+    assert len(delta_product_link_df) == 2
+    assert set(delta_product_link_df["offer_product_id"]) == {2, 3}
+    assert delta_product_link_df["artist_id"].isna().sum() == 0
+
+    # Verify delta_artist:
+    # Should contain Ed Sheeran (matched Q2) and Unknown Band (not matched to any wikidata_id)
+    # Note: since Unknown Band is not matched to wikidata, does it get added to delta_artist?
+    # Let's check: in create_artists_tables, delta_artist_df is generated from exploded_artist_alias_df
+    # which is returned by match_artists_with_wikidata.
+    # On master, match_artists_with_wikidata returned all clusters (matched and unmatched).
+    # So both should be in delta_artist_df.
+    assert len(delta_artist_df) == 2
+    names = set(delta_artist_df[ARTIST_NAME_KEY])
+    assert "Ed Sheeran" in names
+    assert "Unknown Band" in names
+
+    # Ed Sheeran should have wikidata_id Q2
+    ed_sheeran = delta_artist_df[delta_artist_df[ARTIST_NAME_KEY] == "Ed Sheeran"].iloc[
+        0
+    ]
+    assert ed_sheeran[WIKIDATA_ID_KEY] == "Q2"
+
+    # Unknown Band should have NaN wikidata_id
+    unknown_band = delta_artist_df[
+        delta_artist_df[ARTIST_NAME_KEY] == "Unknown Band"
+    ].iloc[0]
+    assert pd.isna(unknown_band[WIKIDATA_ID_KEY])

--- a/jobs/ml_jobs/artist_linkage/tests/refresh_artist_metadatas_test.py
+++ b/jobs/ml_jobs/artist_linkage/tests/refresh_artist_metadatas_test.py
@@ -1,0 +1,225 @@
+import os
+from unittest.mock import patch
+
+import pandas as pd
+
+from cli.refresh_artist_metadatas import main
+from src.constants import (
+    ARTIST_DESCRIPTION_KEY,
+    ARTIST_ID_KEY,
+    ARTIST_NAME_KEY,
+    ARTIST_PRO_SEARCH_SCORE_KEY,
+    IMG_KEY,
+    WIKIDATA_ID_KEY,
+    WIKIPEDIA_URL_KEY,
+)
+
+
+def test_refresh_artist_metadatas_matching(tmp_path):
+    # 1. Setup mock data files
+    artist_file = tmp_path / "applicative_artist.parquet"
+    product_artist_link_file = tmp_path / "product_artist_link.parquet"
+    product_file = tmp_path / "product.parquet"
+
+    output_delta_artist = tmp_path / "delta_artist.parquet"
+    output_delta_artist_alias = tmp_path / "delta_artist_alias.parquet"
+    output_delta_product_link = tmp_path / "delta_product_link.parquet"
+
+    # Mock applicative database artists:
+    # id1 is already matched to Q1
+    # id2 is unmatched (wikidata_id = None), name is Ed Sheeran
+    artist_data = {
+        ARTIST_ID_KEY: ["id1", "id2"],
+        ARTIST_NAME_KEY: ["Artist One", "Ed Sheeran"],
+        ARTIST_DESCRIPTION_KEY: [None, None],
+        "wikidata_image_file_url": [None, None],
+        WIKIDATA_ID_KEY: ["Q1", None],
+        WIKIPEDIA_URL_KEY: [None, None],
+        ARTIST_PRO_SEARCH_SCORE_KEY: [10.0, 20.0],
+    }
+    pd.DataFrame(artist_data).to_parquet(artist_file, index=False)
+
+    # Mock product-artist links:
+    # Link unmatched artist id2 to product 10
+    link_data = {
+        "offer_product_id": [10],
+        ARTIST_ID_KEY: ["id2"],
+        "artist_type": ["music"],
+    }
+    pd.DataFrame(link_data).to_parquet(product_artist_link_file, index=False)
+
+    # Mock products:
+    # Product 10 category is SPECTACLE, artist_name is Ed Sheeran
+    product_data = {
+        "offer_product_id": [10],
+        ARTIST_NAME_KEY: ["Ed Sheeran"],
+        "artist_type": ["music"],
+        "offer_category_id": ["SPECTACLE"],
+    }
+    pd.DataFrame(product_data).to_parquet(product_file, index=False)
+
+    # Mock wikidata dump:
+    # Q1: already matched, gets updated description
+    # Q2: matching Ed Sheeran (music=True, raw_alias=Ed Sheeran)
+    wiki_data = {
+        WIKIDATA_ID_KEY: ["Q1", "Q2"],
+        "artist_name": ["Artist One", "Ed Sheeran"],
+        "alias": ["Artist One", "Ed Sheeran"],
+        "raw_alias": ["Artist One", "Ed Sheeran"],
+        "matching_score": [1.0, 1.0],
+        "gkg": [100, 200],
+        "music": [True, True],
+        "book": [False, False],
+        "movie": [False, False],
+        ARTIST_DESCRIPTION_KEY: [
+            "Refreshed Description One",
+            "English singer-songwriter",
+        ],
+        "img": ["img1.jpg", "img2.jpg"],
+        WIKIPEDIA_URL_KEY: [
+            "https://wikipedia.org/wiki/Artist_One",
+            "https://wikipedia.org/wiki/Ed_Sheeran",
+        ],
+    }
+
+    # Mock environment variable to bypass ENV_SHORT_NAME check if needed, but we can set it to dev
+    # which skips the sanity threshold checks.
+    os.environ["ENV_SHORT_NAME"] = "dev"
+
+    # 3. Call main using direct execution with patch for load_wikidata
+    with patch("cli.refresh_artist_metadatas.load_wikidata") as mock_load:
+        mock_load.return_value = pd.DataFrame(wiki_data)
+
+        main(
+            artist_file_path=str(artist_file),
+            product_artist_link_filepath=str(product_artist_link_file),
+            product_filepath=str(product_file),
+            wiki_base_path=str(tmp_path),  # dummy path
+            wiki_file_name="wiki.parquet",
+            output_delta_artist_file_path=str(output_delta_artist),
+            output_delta_artist_alias_file_path=str(output_delta_artist_alias),
+            output_delta_product_artist_link_file_path=str(output_delta_product_link),
+        )
+
+    # 4. Load outputs and verify
+    delta_artist_df = pd.read_parquet(output_delta_artist)
+    delta_artist_alias_df = pd.read_parquet(output_delta_artist_alias)
+    delta_product_link_df = pd.read_parquet(output_delta_product_link)
+
+    # Output product link delta should be empty
+    assert len(delta_product_link_df) == 0
+
+    # Delta artist should contain two updates: Q1 and Q2
+    assert len(delta_artist_df) == 2
+
+    # Check already matched artist (id1)
+    artist_1 = delta_artist_df[delta_artist_df[ARTIST_ID_KEY] == "id1"].iloc[0]
+    assert artist_1[WIKIDATA_ID_KEY] == "Q1"
+    assert artist_1[ARTIST_DESCRIPTION_KEY] == "Refreshed Description One"
+    assert artist_1[IMG_KEY] == "img1.jpg"
+
+    # Check newly matched artist (id2)
+    artist_2 = delta_artist_df[delta_artist_df[ARTIST_ID_KEY] == "id2"].iloc[0]
+    assert artist_2[WIKIDATA_ID_KEY] == "Q2"
+    assert artist_2[ARTIST_DESCRIPTION_KEY] == "English singer-songwriter"
+    assert artist_2[IMG_KEY] == "img2.jpg"
+
+    # Delta artist alias should contain the new match for id2/Q2
+    assert len(delta_artist_alias_df) == 0
+
+
+def test_refresh_artist_metadatas_duplicate_wikidata_id_resolution(tmp_path):
+    # 1. Setup mock data files
+    artist_file = tmp_path / "applicative_artist.parquet"
+    product_artist_link_file = tmp_path / "product_artist_link.parquet"
+    product_file = tmp_path / "product.parquet"
+
+    output_delta_artist = tmp_path / "delta_artist.parquet"
+    output_delta_artist_alias = tmp_path / "delta_artist_alias.parquet"
+    output_delta_product_link = tmp_path / "delta_product_link.parquet"
+
+    # Three unmatched artists: id2 (Ed Sheeran), id3 (Edward Sheeran), id4 (Eddie Sheeran)
+    artist_data = {
+        ARTIST_ID_KEY: ["id2", "id3", "id4"],
+        ARTIST_NAME_KEY: ["Ed Sheeran", "Edward Sheeran", "Eddie Sheeran"],
+        ARTIST_DESCRIPTION_KEY: [None, None, None],
+        "wikidata_image_file_url": [None, None, None],
+        WIKIDATA_ID_KEY: [None, None, None],
+        WIKIPEDIA_URL_KEY: [None, None, None],
+        ARTIST_PRO_SEARCH_SCORE_KEY: [10.0, 50.0, 5.0],
+    }
+    pd.DataFrame(artist_data).to_parquet(artist_file, index=False)
+
+    # Link unmatched artists to products to create different product counts:
+    # id2 (Ed Sheeran) has 1 product
+    # id3 (Edward Sheeran) has 3 products
+    # id4 (Eddie Sheeran) has 0 products
+    link_data = {
+        "offer_product_id": [10, 20, 21, 22],
+        ARTIST_ID_KEY: ["id2", "id3", "id3", "id3"],
+        "artist_type": ["music", "music", "music", "music"],
+    }
+    pd.DataFrame(link_data).to_parquet(product_artist_link_file, index=False)
+
+    product_data = {
+        "offer_product_id": [10, 20, 21, 22],
+        ARTIST_NAME_KEY: [
+            "Ed Sheeran",
+            "Edward Sheeran",
+            "Edward Sheeran",
+            "Edward Sheeran",
+        ],
+        "artist_type": ["music", "music", "music", "music"],
+        "offer_category_id": ["SPECTACLE", "SPECTACLE", "SPECTACLE", "SPECTACLE"],
+    }
+    pd.DataFrame(product_data).to_parquet(product_file, index=False)
+
+    # All three will match the same wikidata id Q2
+    # Since Q2 matches all three, and they are duplicated on WIKIDATA_ID_KEY,
+    # id3 (highest product count = 3) should be selected.
+    wiki_data = {
+        WIKIDATA_ID_KEY: ["Q2", "Q2", "Q2"],
+        "artist_name": ["Ed Sheeran", "Edward Sheeran", "Eddie Sheeran"],
+        "alias": ["Ed Sheeran", "Edward Sheeran", "Eddie Sheeran"],
+        "raw_alias": ["Ed Sheeran", "Edward Sheeran", "Eddie Sheeran"],
+        "matching_score": [1.0, 1.0, 1.0],
+        "gkg": [200, 200, 200],
+        "music": [True, True, True],
+        "book": [False, False, False],
+        "movie": [False, False, False],
+        ARTIST_DESCRIPTION_KEY: [
+            "Ed Sheeran singer",
+            "Edward Sheeran singer",
+            "Eddie Sheeran singer",
+        ],
+        "img": ["img2.jpg", "img3.jpg", "img4.jpg"],
+        WIKIPEDIA_URL_KEY: [
+            "https://wikipedia.org/wiki/Ed_Sheeran",
+            "https://wikipedia.org/wiki/Edward_Sheeran",
+            "https://wikipedia.org/wiki/Eddie_Sheeran",
+        ],
+    }
+
+    os.environ["ENV_SHORT_NAME"] = "dev"
+
+    with patch("cli.refresh_artist_metadatas.load_wikidata") as mock_load:
+        mock_load.return_value = pd.DataFrame(wiki_data)
+
+        main(
+            artist_file_path=str(artist_file),
+            product_artist_link_filepath=str(product_artist_link_file),
+            product_filepath=str(product_file),
+            wiki_base_path=str(tmp_path),
+            wiki_file_name="wiki.parquet",
+            output_delta_artist_file_path=str(output_delta_artist),
+            output_delta_artist_alias_file_path=str(output_delta_artist_alias),
+            output_delta_product_artist_link_file_path=str(output_delta_product_link),
+        )
+
+    delta_artist_df = pd.read_parquet(output_delta_artist)
+
+    # Only id3 should be matched to Q2, id2 and id4 should not be in the delta
+    assert len(delta_artist_df) == 1
+    matched_artist = delta_artist_df.iloc[0]
+    assert matched_artist[ARTIST_ID_KEY] == "id3"
+    assert matched_artist[WIKIDATA_ID_KEY] == "Q2"

--- a/orchestration/dags/jobs/ml/artist_linkage.py
+++ b/orchestration/dags/jobs/ml/artist_linkage.py
@@ -357,6 +357,8 @@ with DAG(
         command=f"""
              uv run cli/refresh_artist_metadatas.py \
             --artist-file-path {os.path.join(STORAGE_BASE_PATH, APPLICATIVE_ARTISTS_GCS_FILENAME)} \
+            --product-artist-link-filepath {os.path.join(STORAGE_BASE_PATH, APPLICATIVE_PRODUCT_ARTIST_LINK_GCS_FILENAME)} \
+            --product-filepath {os.path.join(STORAGE_BASE_PATH, PRODUCTS_TO_LINK_GCS_FILENAME)} \
             --wiki-base-path {WIKIDATA_STORAGE_BASE_PATH} \
             --wiki-file-name {WIKIDATA_EXTRACTION_GCS_FILENAME} \
             --output-delta-artist-file-path {os.path.join(STORAGE_BASE_PATH, DELTA_ARTISTS_GCS_FILENAME_01)} \


### PR DESCRIPTION
## Summary

This PR adds metadata matching capabilities for **existing unmatched artists** (those without a `wikidata_id`) during the `refresh_artist_metadatas` job, and cleans up naming conventions across the artist linkage codebase.

### What it does

1. **Matches unmatched artists to Wikidata** during the refresh flow — previously, the refresh job only updated metadata for artists that already had a `wikidata_id`. Now it also attempts to match artists that don't yet have one. **The matching is performed on the primary artist name (from `applicative_artist_df`) rather than the full set of artist aliases, while still using product-artist links and product details to retrieve the offer category and artist type.**

2. **Duplicate resolution** — when multiple artists match the same `wikidata_id`, the artist with the highest `artist_pro_search_score` is selected. Per-artist deduplication ensures each artist gets at most one `wikidata_id`.

3. **Extracts `perform_wikidata_category_matching`** from `match_artists_with_wikidata` as a shared utility, so both the incremental and refresh flows can reuse the same matching logic.

4. **Cleans up `tmp_id` naming** — the `tmp_id` column was a legacy from `link_new_products_to_artists.py` where it held a temporary UUID. In the refresh flow, it was actually the real `artist_id`. This PR:
   - Replaces all `tmp_id` references with `ARTIST_ID_KEY` across `matching.py`, `link_new_products_to_artists.py`, and `refresh_artist_metadatas.py`
   - Renames `new_artist_clusters_df` → `unmatched_artist_clusters_df` in the refresh flow (these are existing artists, not new ones)

5. **Carries `artist_pro_search_score` through the pipeline** — instead of re-merging it from `applicative_artist_df` after wikidata matching, the score is now propagated directly from the initial selection of unmatched artists to the matching steps.

### Files changed

| File | Change |
|------|--------|
| `cli/refresh_artist_metadatas.py` | Added `match_unmatched_artists_with_wikidata`, updated `create_delta_df_for_metadata_refresh` to accept newly matched artists, added new CLI args |
| `src/utils/matching.py` | Extracted `perform_wikidata_category_matching`, replaced `tmp_id` with `ARTIST_ID_KEY` |
| `cli/link_new_products_to_artists.py` | Renamed `tmp_id` column to `ARTIST_ID_KEY` in cluster aggregation |
| `src/constants.py` | Added `ARTIST_PRO_SEARCH_SCORE_KEY` constant |
| `tests/refresh_artist_metadatas_test.py` | Added tests for matching + duplicate `wikidata_id` resolution |
| `orchestration/dags/jobs/ml/artist_linkage.py` | Added `--product-artist-link-filepath` and `--product-filepath` CLI args to the refresh task |
