### PR TITLE
(BSR) fix(clickhouse): add partition by offer_id (offer_consultation_cumulative)

### DIFF
--- a/jobs/etl_jobs/internal/export_clickhouse/schema/analytics/offer_consultation_cumulative.sql
+++ b/jobs/etl_jobs/internal/export_clickhouse/schema/analytics/offer_consultation_cumulative.sql
@@ -18,5 +18,5 @@ WITH offer_consultations AS (
 SELECT
     partition_date,
     offer_id,
-    sum(consultation_cnt) OVER (ORDER BY partition_date ASC) AS consultation_cumulative_cnt
+    sum(consultation_cnt) OVER (PARTITION BY offer_id ORDER BY partition_date ASC) AS consultation_cumulative_cnt
 FROM offer_consultations


### PR DESCRIPTION
## Summary
Fix incorrect cumulative consultation count in `offer_consultation_cumulative` export. The window function was missing `PARTITION BY offer_id`, causing the cumulative sum to be computed across all offers instead of per offer.

## Changes
- Add `PARTITION BY offer_id` to the cumulative window function

## Testing
Verified SQL logic — cumulative count now correctly resets per offer.