### PR TITLE
(DE-4252) feat(events): Add mode preingestion checks

### DIFF
--- a/jobs/ml_jobs/event_linkage/cli/3_create_delta_event_tables.py
+++ b/jobs/ml_jobs/event_linkage/cli/3_create_delta_event_tables.py
@@ -10,7 +10,9 @@ from src.clustering import (
     get_uuid_from_cluster,
 )
 from src.constants import (
+    EVENT_DESCRIPTION_COL,
     EVENT_ID_COL,
+    EVENT_IMAGE_URL_COL,
     EVENT_NAME_COL,
     EVENT_SERIES_ID_COL,
     IMAGE_URL_COL,
@@ -196,8 +198,22 @@ def main(
     logger.success(f"Removed {len(removed_events_df)} events with no active offers.")
 
     # 6. Assemble and save delta tables
+    delta_events_df = (
+        pd.DataFrame(delta_events)
+        if delta_events
+        else pd.DataFrame(
+            columns=[
+                EVENT_ID_COL,
+                EVENT_NAME_COL,
+                EVENT_DESCRIPTION_COL,
+                EVENT_IMAGE_URL_COL,
+                "action",
+                "comment",
+            ]
+        )
+    )
     all_delta_events_df = pd.concat(
-        [pd.DataFrame(delta_events), removed_events_df], ignore_index=True
+        [delta_events_df, removed_events_df], ignore_index=True
     )
     delta_event_offer_links_df = (
         pd.DataFrame(delta_event_offer_links)

--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/export/backend/description__exp_backend__event_series_pre_ingestion_checks.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/export/backend/description__exp_backend__event_series_pre_ingestion_checks.md
@@ -10,4 +10,14 @@ description: Description of the `exp_backend__event_series_pre_ingestion_checks`
 The `exp_backend__event_series_pre_ingestion_checks` table aggregates data quality checks on the future event series and event series / offer link data before they are ingested by the backend application.
 This table will be read by the backend application to determine if the data is ready for ingestion (i.e. all checks pass).
 The `ready_for_ingestion` column is `true` when all checks pass (all counts equal zero).
+
+The checks cover:
+
+- **Uniqueness**: duplicate `event_series_id` in the future event series data, and duplicate `(offer_id, event_series_id)` pairs in the future links.
+- **Null keys**: null or empty `event_series_id`, `offer_id`, or `event_series_name`.
+- **Referential integrity**: future links pointing to an `event_series_id` that doesn't exist in the future event series data.
+- **Delta validity**: rows in either delta with a null action or an action outside `add`, `update`, `remove`.
+- **Business rules**: an offer linked to more than one event series; an added/updated event series with an image url but no extracted mediation uuid.
+- **Shrinkage guard**: the future event series (or offer link) row count drops below 30% of the current applicative row count, which would indicate a pathological delta wiping out most of the table.
+
 {% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/_schema/exp_backend__event_series_pre_ingestion_checks.yml
+++ b/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/_schema/exp_backend__event_series_pre_ingestion_checks.yml
@@ -10,5 +10,23 @@ models:
         description: "Number of rows with a null or empty event_series_name in the future event series data."
       - name: count_duplicate_links_in_future_event_series_offer_link
         description: "Number of duplicate (offer_id, event_series_id) pairs in the future event series offer link data."
+      - name: count_orphan_event_series_in_future_event_series_offer_link
+        description: "Number of future event series offer links whose event_series_id does not exist in the future event series data."
+      - name: count_event_series_id_null_or_empty_in_future_event_series
+        description: "Number of rows with a null or empty event_series_id in the future event series data."
+      - name: count_null_or_empty_keys_in_future_event_series_offer_link
+        description: "Number of rows with a null or empty event_series_id or offer_id in the future event series offer link data."
+      - name: count_invalid_actions_in_event_series_delta
+        description: "Number of rows in the event series delta with a null action or an action other than add, update, or remove."
+      - name: count_invalid_actions_in_event_series_offer_link_delta
+        description: "Number of rows in the event series offer link delta with a null action or an action other than add, update, or remove."
+      - name: count_offers_linked_to_multiple_event_series
+        description: "Number of offers linked to more than one event series in the future event series offer link data."
+      - name: count_missing_mediation_uuid_in_event_series_delta
+        description: "Number of added or updated rows in the event series delta with an image url but a null or empty mediation uuid."
+      - name: count_future_event_series_below_shrinkage_threshold
+        description: "Flag (0 or 1) set to 1 when the future event series row count drops below 30% of the current applicative event series row count."
+      - name: count_future_event_series_offer_link_below_shrinkage_threshold
+        description: "Flag (0 or 1) set to 1 when the future event series offer link row count drops below 30% of the current applicative event series offer link row count."
       - name: ready_for_ingestion
         description: "Boolean flag that is true when all check counts are zero, indicating the data is ready for backend ingestion."

--- a/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__event_series_pre_ingestion_checks.sql
+++ b/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__event_series_pre_ingestion_checks.sql
@@ -61,6 +61,54 @@ with
         where action in ("add", "update")
     ),
 
+    -- ----------------- DELTA CHECKS -------------------
+    check_event_series_id_in_delta as (
+        select
+            countif(
+                event_series_id is null or event_series_id = ""
+            ) as count_event_series_id_null_or_empty_in_event_series_delta
+        from event_series_delta
+    ),
+
+    check_event_series_name_in_delta as (
+        select
+            countif(
+                event_series_name is null or event_series_name = ""
+            ) as count_event_series_name_null_or_empty_in_event_series_delta
+        from event_series_delta
+    ),
+
+    check_invalid_actions_in_event_series_delta as (
+        select
+            countif(
+                action is null or action not in ("add", "update", "remove")
+            ) as count_invalid_actions_in_event_series_delta
+        from event_series_delta
+    ),
+
+    check_invalid_actions_in_event_series_offer_link_delta as (
+        select
+            countif(
+                action is null or action not in ("add", "update", "remove")
+            ) as count_invalid_actions_in_event_series_offer_link_delta
+        from event_series_offer_link_delta
+    ),
+
+    check_missing_mediation_uuid_in_event_series_delta as (
+        select
+            countif(
+                event_series_image_url is not null
+                and event_series_image_url != ""
+                and (
+                    event_series_mediation_uuid is null
+                    or event_series_mediation_uuid = ""
+                )
+            ) as count_missing_mediation_uuid_in_event_series_delta
+        from event_series_delta
+        where action in ("add", "update")
+    ),
+
+    -- ----------------- FUTURE CHECKS -------------------
     check_event_series_id_duplicates_in_future_event_series as (
         select
             count(*) - count(
@@ -118,43 +166,15 @@ with
         from future_event_series_offer_link
     ),
 
-    check_invalid_actions_in_event_series_delta as (
+    check_offers_linked_to_multiple_event_series_in_future as (
         select
-            countif(
-                action is null or action not in ("add", "update", "remove")
-            ) as count_invalid_actions_in_event_series_delta
-        from event_series_delta
-    ),
-
-    check_invalid_actions_in_event_series_offer_link_delta as (
-        select
-            countif(
-                action is null or action not in ("add", "update", "remove")
-            ) as count_invalid_actions_in_event_series_offer_link_delta
-        from event_series_offer_link_delta
-    ),
-
-    check_offers_linked_to_multiple_event_series as (
-        select
-            count(distinct to_json_string(struct(event_series_id, offer_id)))
-            - count(distinct offer_id) as count_offers_linked_to_multiple_event_series
+            count(distinct to_json_string(struct(event_series_id, offer_id))) - count(
+                distinct offer_id
+            ) as count_offers_linked_to_multiple_event_series_in_future
         from future_event_series_offer_link
     ),
 
-    check_missing_mediation_uuid_in_event_series_delta as (
-        select
-            countif(
-                event_series_image_url is not null
-                and event_series_image_url != ""
-                and (
-                    event_series_mediation_uuid is null
-                    or event_series_mediation_uuid = ""
-                )
-            ) as count_missing_mediation_uuid_in_event_series_delta
-        from event_series_delta
-        where action in ("add", "update")
-    ),
-
+    -- -------------------- VOLUME CHECKS ----------------------
     check_future_event_series_shrinkage as (
         select
             if(
@@ -188,16 +208,21 @@ with
 
     aggregated_checks as (
         select
+            -- - DELTA CHECKS ---
+            check_event_series_id_in_delta.count_event_series_id_null_or_empty_in_event_series_delta,
+            check_event_series_name_in_delta.count_event_series_name_null_or_empty_in_event_series_delta,
+            check_invalid_actions_in_event_series_delta.count_invalid_actions_in_event_series_delta,
+            check_invalid_actions_in_event_series_offer_link_delta.count_invalid_actions_in_event_series_offer_link_delta,
+            check_missing_mediation_uuid_in_event_series_delta.count_missing_mediation_uuid_in_event_series_delta,
+            -- - FUTURE CHECKS ---
             check_event_series_id_duplicates_in_future_event_series.count_event_series_id_duplicates_in_future_event_series,
             check_event_series_name_in_future_event_series.count_event_series_name_null_or_empty_in_future_event_series,
             check_duplicate_links_in_future_event_series_offer_link.count_duplicate_links_in_future_event_series_offer_link,
             check_orphan_event_series_in_future_event_series_offer_link.count_orphan_event_series_in_future_event_series_offer_link,
             check_event_series_id_null_or_empty_in_future_event_series.count_event_series_id_null_or_empty_in_future_event_series,
             check_null_or_empty_keys_in_future_event_series_offer_link.count_null_or_empty_keys_in_future_event_series_offer_link,
-            check_invalid_actions_in_event_series_delta.count_invalid_actions_in_event_series_delta,
-            check_invalid_actions_in_event_series_offer_link_delta.count_invalid_actions_in_event_series_offer_link_delta,
-            check_offers_linked_to_multiple_event_series.count_offers_linked_to_multiple_event_series,
-            check_missing_mediation_uuid_in_event_series_delta.count_missing_mediation_uuid_in_event_series_delta,
+            check_offers_linked_to_multiple_event_series_in_future.count_offers_linked_to_multiple_event_series_in_future,
+            -- - VOLUME CHECKS ---
             check_future_event_series_shrinkage.count_future_event_series_below_shrinkage_threshold,
             check_future_event_series_offer_link_shrinkage.count_future_event_series_offer_link_below_shrinkage_threshold
 
@@ -209,10 +234,12 @@ with
         cross join check_null_or_empty_keys_in_future_event_series_offer_link
         cross join check_invalid_actions_in_event_series_delta
         cross join check_invalid_actions_in_event_series_offer_link_delta
-        cross join check_offers_linked_to_multiple_event_series
+        cross join check_offers_linked_to_multiple_event_series_in_future
         cross join check_missing_mediation_uuid_in_event_series_delta
         cross join check_future_event_series_shrinkage
         cross join check_future_event_series_offer_link_shrinkage
+        cross join check_event_series_id_in_delta
+        cross join check_event_series_name_in_delta
     )
 
 select
@@ -226,10 +253,12 @@ select
         + count_null_or_empty_keys_in_future_event_series_offer_link
         + count_invalid_actions_in_event_series_delta
         + count_invalid_actions_in_event_series_offer_link_delta
-        + count_offers_linked_to_multiple_event_series
+        + count_offers_linked_to_multiple_event_series_in_future
         + count_missing_mediation_uuid_in_event_series_delta
         + count_future_event_series_below_shrinkage_threshold
         + count_future_event_series_offer_link_below_shrinkage_threshold
+        + count_event_series_id_null_or_empty_in_event_series_delta
+        + count_event_series_name_null_or_empty_in_event_series_delta
     )
     = 0 as ready_for_ingestion
 from aggregated_checks

--- a/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__event_series_pre_ingestion_checks.sql
+++ b/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__event_series_pre_ingestion_checks.sql
@@ -1,18 +1,37 @@
+{% set shrinkage_threshold = 0.3 %}
+
 with
-    future_event_series as (
+
+    event_series_delta as (
         select
             event_series_id,
             event_series_name,
             event_series_description,
-            event_series_mediation_uuid
-        from {{ source("raw", "applicative_database_event_series") }}
+            event_series_image_url,
+            event_series_mediation_uuid,
+            action
+        from {{ ref("exp_backend__event_series_delta") }}
+    ),
+
+    event_series_offer_link_delta as (
+        select event_series_id, cast(offer_id as string) as offer_id, action
+        from {{ ref("exp_backend__event_series_offer_link_delta") }}
+    ),
+
+    future_event_series as (
+        select
+            base.event_series_id,
+            base.event_series_name,
+            base.event_series_description,
+            base.event_series_mediation_uuid
+        from {{ source("raw", "applicative_database_event_series") }} as base
         where
-            event_series_id not in (
-                select distinct event_series_delta.event_series_id
-                from {{ ref("exp_backend__event_series_delta") }} as event_series_delta
+            not exists (
+                select 1 as found
+                from event_series_delta as delta
                 where
-                    event_series_delta.action = "remove"
-                    or event_series_delta.action = "update"
+                    delta.action in ("remove", "update")
+                    and delta.event_series_id = base.event_series_id
             )
         union all
         select
@@ -20,35 +39,26 @@ with
             event_series_name,
             cast(event_series_description as string) as event_series_description,
             event_series_mediation_uuid
-        from {{ ref("exp_backend__event_series_delta") }}
-        where action = "add" or action = "update"
+        from event_series_delta
+        where action in ("add", "update")
     ),
 
     future_event_series_offer_link as (
-        select
-            event_series_id,
-            cast(offer_id as string) as offer_id,
-            concat(event_series_id, offer_id) as concat_id
-        from {{ source("raw", "applicative_database_event_series_offer_link") }}
+        select base.event_series_id, cast(base.offer_id as string) as offer_id
+        from {{ source("raw", "applicative_database_event_series_offer_link") }} as base
         where
-            concat(event_series_id, offer_id) not in (
-
-                select
-                    concat(
-                        event_series_offer_link_delta.event_series_id,
-                        event_series_offer_link_delta.offer_id
-                    ) as concat_id
-                from
-                    {{ ref("exp_backend__event_series_offer_link_delta") }}
-                    as event_series_offer_link_delta
+            not exists (
+                select 1 as found
+                from event_series_offer_link_delta as delta
                 where
-                    event_series_offer_link_delta.action = "remove"
-                    or event_series_offer_link_delta.action = "update"
+                    delta.action in ("remove", "update")
+                    and delta.event_series_id = base.event_series_id
+                    and delta.offer_id = cast(base.offer_id as string)
             )
         union all
-        select event_series_id, offer_id, concat(event_series_id, offer_id) as concat_id
-        from {{ ref("exp_backend__event_series_offer_link_delta") }}
-        where action = "add" or action = "update"
+        select event_series_id, offer_id
+        from event_series_offer_link_delta
+        where action in ("add", "update")
     ),
 
     check_event_series_id_duplicates_in_future_event_series as (
@@ -75,15 +85,134 @@ with
         from future_event_series_offer_link
     ),
 
+    check_orphan_event_series_in_future_event_series_offer_link as (
+        select
+            countif(
+                not exists (
+                    select 1 as found
+                    from future_event_series
+                    where
+                        future_event_series.event_series_id
+                        = future_event_series_offer_link.event_series_id
+                )
+            ) as count_orphan_event_series_in_future_event_series_offer_link
+        from future_event_series_offer_link
+    ),
+
+    check_event_series_id_null_or_empty_in_future_event_series as (
+        select
+            countif(
+                event_series_id is null or event_series_id = ""
+            ) as count_event_series_id_null_or_empty_in_future_event_series
+        from future_event_series
+    ),
+
+    check_null_or_empty_keys_in_future_event_series_offer_link as (
+        select
+            countif(
+                event_series_id is null
+                or event_series_id = ""
+                or offer_id is null
+                or offer_id = ""
+            ) as count_null_or_empty_keys_in_future_event_series_offer_link
+        from future_event_series_offer_link
+    ),
+
+    check_invalid_actions_in_event_series_delta as (
+        select
+            countif(
+                action is null or action not in ("add", "update", "remove")
+            ) as count_invalid_actions_in_event_series_delta
+        from event_series_delta
+    ),
+
+    check_invalid_actions_in_event_series_offer_link_delta as (
+        select
+            countif(
+                action is null or action not in ("add", "update", "remove")
+            ) as count_invalid_actions_in_event_series_offer_link_delta
+        from event_series_offer_link_delta
+    ),
+
+    check_offers_linked_to_multiple_event_series as (
+        select
+            count(distinct to_json_string(struct(event_series_id, offer_id)))
+            - count(distinct offer_id) as count_offers_linked_to_multiple_event_series
+        from future_event_series_offer_link
+    ),
+
+    check_missing_mediation_uuid_in_event_series_delta as (
+        select
+            countif(
+                event_series_image_url is not null
+                and event_series_image_url != ""
+                and (
+                    event_series_mediation_uuid is null
+                    or event_series_mediation_uuid = ""
+                )
+            ) as count_missing_mediation_uuid_in_event_series_delta
+        from event_series_delta
+        where action in ("add", "update")
+    ),
+
+    check_future_event_series_shrinkage as (
+        select
+            if(
+                (select count(*) as row_count from future_event_series) < (
+                    select count(*) as row_count
+                    from {{ source("raw", "applicative_database_event_series") }}
+                )
+                * {{ shrinkage_threshold }},
+                1,
+                0
+            ) as count_future_event_series_below_shrinkage_threshold
+    ),
+
+    check_future_event_series_offer_link_shrinkage as (
+        select
+            if(
+                (select count(*) as row_count from future_event_series_offer_link) < (
+                    select count(*) as row_count
+                    from
+                        {{
+                            source(
+                                "raw", "applicative_database_event_series_offer_link"
+                            )
+                        }}
+                )
+                * {{ shrinkage_threshold }},
+                1,
+                0
+            ) as count_future_event_series_offer_link_below_shrinkage_threshold
+    ),
+
     aggregated_checks as (
         select
             check_event_series_id_duplicates_in_future_event_series.count_event_series_id_duplicates_in_future_event_series,
             check_event_series_name_in_future_event_series.count_event_series_name_null_or_empty_in_future_event_series,
-            check_duplicate_links_in_future_event_series_offer_link.count_duplicate_links_in_future_event_series_offer_link
+            check_duplicate_links_in_future_event_series_offer_link.count_duplicate_links_in_future_event_series_offer_link,
+            check_orphan_event_series_in_future_event_series_offer_link.count_orphan_event_series_in_future_event_series_offer_link,
+            check_event_series_id_null_or_empty_in_future_event_series.count_event_series_id_null_or_empty_in_future_event_series,
+            check_null_or_empty_keys_in_future_event_series_offer_link.count_null_or_empty_keys_in_future_event_series_offer_link,
+            check_invalid_actions_in_event_series_delta.count_invalid_actions_in_event_series_delta,
+            check_invalid_actions_in_event_series_offer_link_delta.count_invalid_actions_in_event_series_offer_link_delta,
+            check_offers_linked_to_multiple_event_series.count_offers_linked_to_multiple_event_series,
+            check_missing_mediation_uuid_in_event_series_delta.count_missing_mediation_uuid_in_event_series_delta,
+            check_future_event_series_shrinkage.count_future_event_series_below_shrinkage_threshold,
+            check_future_event_series_offer_link_shrinkage.count_future_event_series_offer_link_below_shrinkage_threshold
 
         from check_event_series_id_duplicates_in_future_event_series
         cross join check_event_series_name_in_future_event_series
         cross join check_duplicate_links_in_future_event_series_offer_link
+        cross join check_orphan_event_series_in_future_event_series_offer_link
+        cross join check_event_series_id_null_or_empty_in_future_event_series
+        cross join check_null_or_empty_keys_in_future_event_series_offer_link
+        cross join check_invalid_actions_in_event_series_delta
+        cross join check_invalid_actions_in_event_series_offer_link_delta
+        cross join check_offers_linked_to_multiple_event_series
+        cross join check_missing_mediation_uuid_in_event_series_delta
+        cross join check_future_event_series_shrinkage
+        cross join check_future_event_series_offer_link_shrinkage
     )
 
 select
@@ -92,6 +221,15 @@ select
         count_event_series_id_duplicates_in_future_event_series
         + count_event_series_name_null_or_empty_in_future_event_series
         + count_duplicate_links_in_future_event_series_offer_link
+        + count_orphan_event_series_in_future_event_series_offer_link
+        + count_event_series_id_null_or_empty_in_future_event_series
+        + count_null_or_empty_keys_in_future_event_series_offer_link
+        + count_invalid_actions_in_event_series_delta
+        + count_invalid_actions_in_event_series_offer_link_delta
+        + count_offers_linked_to_multiple_event_series
+        + count_missing_mediation_uuid_in_event_series_delta
+        + count_future_event_series_below_shrinkage_threshold
+        + count_future_event_series_offer_link_below_shrinkage_threshold
     )
     = 0 as ready_for_ingestion
 from aggregated_checks

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series.sql
@@ -1,19 +1,32 @@
+with
+    casted_delta_event_series as (
+        select
+            cast(event_id as string) as event_series_id,
+            cast(event_description as string) as event_series_description,
+            cast(event_image_url as string) as event_series_image_url,
+            cast(action as string) as action,  -- noqa: disable=RF04
+            cast(comment as string) as comment,
+            cast(event_name as string) as event_name
+        from {{ source("ml_preproc", "delta_event_series") }}
+    )
+
 select
-    delta_event_series.event_id as event_series_id,
-    delta_event_series.event_description as event_series_description,
-    delta_event_series.event_image_url as event_series_image_url,
-    delta_event_series.action,
-    delta_event_series.comment,
+    casted_delta_event_series.event_series_id,
+    casted_delta_event_series.event_series_description,
+    casted_delta_event_series.event_series_image_url,
+    casted_delta_event_series.action,
+    casted_delta_event_series.comment,
     case
-        when delta_event_series.action = 'remove'
+        when casted_delta_event_series.action = 'remove'
         then applicative_database_event_series.event_series_name
-        else delta_event_series.event_name
+        else casted_delta_event_series.event_name
     end as event_series_name,
     regexp_extract(
-        delta_event_series.event_image_url, r'/mediations/([^/]+)'
+        casted_delta_event_series.event_series_image_url, r'/mediations/([^/]+)'
     ) as event_series_mediation_uuid
-from {{ source("ml_preproc", "delta_event_series") }} as delta_event_series
+from casted_delta_event_series
 left join
     {{ source("raw", "applicative_database_event_series") }}
     as applicative_database_event_series
-    on delta_event_series.event_id = applicative_database_event_series.event_series_id
+    on casted_delta_event_series.event_series_id
+    = applicative_database_event_series.event_series_id

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series_offer_link.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series_offer_link.sql
@@ -1,2 +1,6 @@
-select event_id as event_series_id, offer_id, action, comment
+select
+    cast(event_id as string) as event_series_id,
+    cast(offer_id as string) as offer_id,
+    cast(action as string) as action,  -- noqa: disable=RF04
+    cast(comment as string) as comment
 from {{ source("ml_preproc", "delta_event_series_offer_link") }}


### PR DESCRIPTION
## 🔧 Changes Made

> Le modèle `exp_backend__event_series_pre_ingestion_checks` centralise les contrôles qualité exécutés avant l'ingestion des event series et de leurs liens avec les offres côté backend. Cette PR enrichit fortement ces contrôles (unicité, clés nulles, intégrité référentielle, validité des deltas, règles métier, garde-fou anti-shrinkage) pour fiabiliser le flag `ready_for_ingestion` consommé par le backend, et fiabilise les modèles de delta amont pour supporter le cas des tables vides.

### 🔧 Changements

#### Modèle SQL
- Réécriture des CTEs `future_event_series` / `future_event_series_offer_link` avec `NOT EXISTS` (au lieu de `NOT IN` sur des `concat(...)`), plus robuste et lisible.
- Extraction de CTEs `event_series_delta` / `event_series_offer_link_delta` réutilisées par les nouveaux checks.
- **Nouveaux checks sur les deltas** : `event_series_id` / `event_series_name` nul ou vide, actions invalides (hors `add`/`update`/`remove`), `event_series_mediation_uuid` manquant alors qu'une `event_series_image_url` est renseignée.
- **Nouveaux checks sur les données futures** : `event_series_id` nul/vide, clés nulles/vides sur les liens offre/event series, liens orphelins (event_series_id inconnu dans les futures event series), offre liée à plusieurs event series.
- **Nouveau garde-fou de volume** : détection d'un "shrinkage" (le volume de `future_event_series` ou `future_event_series_offer_link` chute sous 30% du volume applicatif actuel), signe d'un delta pathologique.
- Tous ces nouveaux counts sont agrégés dans `aggregated_checks` et intégrés au calcul de `ready_for_ingestion`.

#### Robustesse tables vides / typage
- `ml_linkage__delta_event_series` / `ml_linkage__delta_event_series_offer_link` : cast explicite en `string` de toutes les colonnes issues des sources `ml_preproc.delta_event_series*`, pour éviter que BigQuery n'infère un type par défaut (ex. `INT64`) quand la table source est vide, ce qui cassait les jointures et le `regexp_extract` en aval.
- CLI `3_create_delta_event_tables.py` : quand `delta_events` est vide, construction d'un `DataFrame` vide avec le schéma de colonnes attendu avant le `concat` avec `removed_events_df`, pour ne pas perdre le typage/les colonnes en sortie.

#### Documentation
- Ajout du doc block dbt `description__exp_backend__event_series_pre_ingestion_checks.md` décrivant la table et l'ensemble des checks.
- Ajout du schema YAML (`_schema/exp_backend__event_series_pre_ingestion_checks.yml`) avec la description de chaque colonne de check.

### 🧪 Comment tester
- `dbt run --select exp_backend__event_series_pre_ingestion_checks` (ou build complet) et vérifier que le modèle compile et s'exécute sans erreur.
- Vérifier que `ready_for_ingestion` reste `true` sur un jeu de données nominal, et passe à `false` en injectant chacun des nouveaux cas invalides (action invalide dans un delta, lien orphelin, offre liée à 2 event series, image sans mediation_uuid, chute de volume > 70%).
- Rejouer le CLI `3_create_delta_event_tables.py` avec un run où `delta_events` (ou la table source `delta_event_series`) est vide, et vérifier que le pipeline dbt en aval ne plante plus sur un problème de typage.

---
**🧭 Review effort : 3/5** — _diff concentré sur un modèle dbt principal + deux petits fixes de robustesse (cast, dataframe vide), logique SQL dense avec de nombreux checks suivant un pattern répétitif à vérifier un par un._
