### PR TITLE
(BSR) feat(airflow): Defer StartGCEOperator while a flex-start request is queued

### DIFF
--- a/orchestration/dags/common/hooks/gce.py
+++ b/orchestration/dags/common/hooks/gce.py
@@ -313,6 +313,23 @@ class DeferrableSSHGCEJobManager(SSHGCEJobManager):
 class GCEHook(GoogleBaseHook):
     _conn = None
 
+    # A VM that reaches one of these will never become RUNNING on its own again.
+    TERMINAL_STATES = frozenset(
+        {"TERMINATED", "SUSPENDED", "SUSPENDING", "STOPPING", "STOPPED"}
+    )
+
+    # Time allowed for provisioning/boot (and, for GPU images, driver install)
+    # after an insert is submitted (or an in-flight instance is adopted), for
+    # ANY provisioning model - not flex-start-specific. GCE instances typically
+    # reach RUNNING within a few minutes; 15 min leaves comfortable room without
+    # dragging out failure detection on a genuinely stuck instance.
+    BOOT_MARGIN_SECONDS = 900
+    # GCP caps how long Dynamic Workload Scheduling (DWS) holds a FLEX_START
+    # request PENDING in queue at 2h; used as a fallback when the caller
+    # doesn't set request_valid_for_duration. Flex-start-specific: STANDARD/
+    # reservation instances have no DWS queue to wait through.
+    FLEX_START_MAX_QUEUE_SECONDS = 7200
+
     def __init__(
         self,
         gcp_project: str = GCP_PROJECT_ID,
@@ -379,14 +396,61 @@ class GCEHook(GoogleBaseHook):
         request_valid_for_duration_seconds: t.Optional[int] = None,
         reservation_name: t.Optional[str] = None,
         wait_for_running: bool = True,
-    ):
-        instances = self.list_instances()
-        instances = [x["name"] for x in instances if x["status"] == "RUNNING"]
-        if instance_name in instances:
-            self.log.info(f"Instance {instance_name} already running, pass.")
-            return
-
+    ) -> bool:
+        """Start (or no-op on) a VM. Returns True if the instance was already RUNNING."""
         is_flex_start = (provisioning_model or "STANDARD").upper() == "FLEX_START"
+        # The DWS queue-cap term only applies to flex-start; STANDARD/reservation
+        # instances only need the general boot margin.
+        wait_timeout = self.BOOT_MARGIN_SECONDS
+        if is_flex_start:
+            wait_timeout += (
+                request_valid_for_duration_seconds or self.FLEX_START_MAX_QUEUE_SECONDS
+            )
+
+        # Check for an existing instance under this name in ANY status, not just
+        # RUNNING: a retried task (e.g. after a triggerer crash orphans a deferred
+        # flex-start wait and Airflow retries execute() from scratch) would
+        # otherwise re-submit an insert for a name that's already mid-provisioning,
+        # which GCE rejects with a 409 "already exists".
+        existing = self.get_instance(instance_name)
+        if existing is not None:
+            status = existing.get("status")
+            if status == "RUNNING":
+                self.log.info(f"Instance {instance_name} already running, pass.")
+                return True
+            if status not in self.TERMINAL_STATES:
+                # Loud on purpose: this instance wasn't just inserted by this
+                # call, so it either belongs to an earlier attempt of this same
+                # task (expected, e.g. after a triggerer crash/retry) or to a
+                # completely different run/DAG that happens to share this
+                # instance_name (a race - nothing here verifies ownership).
+                # provisioning_model=STANDARD is the more suspicious case: it
+                # has no deferral-driven reason for a prior attempt to still be
+                # mid-flight, so seeing this for STANDARD is worth tracing back
+                # to whichever other task/run is targeting the same name.
+                self.log.warning(
+                    f"Instance {instance_name} already exists with status "
+                    f"{status} (a prior insert is still in flight) instead of "
+                    "being created fresh by this call. Adopting it and waiting "
+                    "for it to reach RUNNING instead of re-inserting. If this "
+                    f"is unexpected (provisioning_model={provisioning_model}), "
+                    "check whether another task or DAG run is targeting the "
+                    "same instance_name concurrently."
+                )
+                if wait_for_running:
+                    self.wait_for_instance_running(
+                        instance_name, timeout_seconds=wait_timeout
+                    )
+                return False
+            # Stale instance left over from a previous failed/expired attempt
+            # (e.g. a flex-start request that reached a terminal state before
+            # this retry) - delete it so the retry can submit a fresh insert.
+            self.log.warning(
+                f"Instance {instance_name} exists in terminal state {status}; "
+                "deleting before retrying."
+            )
+            self.__delete_instance(instance_name, wait=True)
+
         self.log.info(
             f"Launching {instance_name} on compute engine (instance: {instance_type}, "
             f"provisioning_model: {provisioning_model})"
@@ -409,7 +473,13 @@ class GCEHook(GoogleBaseHook):
             reservation_name=reservation_name,
         )
         if is_flex_start and wait_for_running:
-            self.wait_for_instance_running(instance_name)
+            # Cover the max queue wait plus provisioning/boot margin, mirroring
+            # the deadline the deferrable path gives GCEInstanceRunningTrigger,
+            # so this synchronous wait doesn't loop forever on a stuck instance.
+            self.wait_for_instance_running(
+                instance_name, timeout_seconds=wait_timeout
+            )
+        return False
 
     def wait_for_instance_running(
         self,

--- a/orchestration/dags/common/hooks/gce.py
+++ b/orchestration/dags/common/hooks/gce.py
@@ -318,16 +318,12 @@ class GCEHook(GoogleBaseHook):
         {"TERMINATED", "SUSPENDED", "SUSPENDING", "STOPPING", "STOPPED"}
     )
 
-    # Time allowed for provisioning/boot (and, for GPU images, driver install)
-    # after an insert is submitted (or an in-flight instance is adopted), for
-    # ANY provisioning model - not flex-start-specific. GCE instances typically
-    # reach RUNNING within a few minutes; 15 min leaves comfortable room without
-    # dragging out failure detection on a genuinely stuck instance.
+    # General margin for VM provisioning and driver installation across all models.
+    # 15 minutes allows a comfortable buffer without delaying failure detection.
     BOOT_MARGIN_SECONDS = 900
-    # GCP caps how long Dynamic Workload Scheduling (DWS) holds a FLEX_START
-    # request PENDING in queue at 2h; used as a fallback when the caller
-    # doesn't set request_valid_for_duration. Flex-start-specific: STANDARD/
-    # reservation instances have no DWS queue to wait through.
+
+    # Fallback matching GCP's maximum 2-hour queue limit for Dynamic Workload
+    # Scheduling (DWS). Only applies to FLEX_START provisioning models.
     FLEX_START_MAX_QUEUE_SECONDS = 7200
 
     def __init__(
@@ -407,11 +403,8 @@ class GCEHook(GoogleBaseHook):
                 request_valid_for_duration_seconds or self.FLEX_START_MAX_QUEUE_SECONDS
             )
 
-        # Check for an existing instance under this name in ANY status, not just
-        # RUNNING: a retried task (e.g. after a triggerer crash orphans a deferred
-        # flex-start wait and Airflow retries execute() from scratch) would
-        # otherwise re-submit an insert for a name that's already mid-provisioning,
-        # which GCE rejects with a 409 "already exists".
+        # Check all statuses to prevent a retried task (e.g., after an Airflow
+        # triggerer crash) from attempting a duplicate insert and hitting a 409 conflict.
         existing = self.get_instance(instance_name)
         if existing is not None:
             status = existing.get("status")
@@ -419,15 +412,10 @@ class GCEHook(GoogleBaseHook):
                 self.log.info(f"Instance {instance_name} already running, pass.")
                 return True
             if status not in self.TERMINAL_STATES:
-                # Loud on purpose: this instance wasn't just inserted by this
-                # call, so it either belongs to an earlier attempt of this same
-                # task (expected, e.g. after a triggerer crash/retry) or to a
-                # completely different run/DAG that happens to share this
-                # instance_name (a race - nothing here verifies ownership).
-                # provisioning_model=STANDARD is the more suspicious case: it
-                # has no deferral-driven reason for a prior attempt to still be
-                # mid-flight, so seeing this for STANDARD is worth tracing back
-                # to whichever other task/run is targeting the same name.
+                # Warn if an existing instance is found mid-flight. While expected on task
+                # retry, it could signal a naming collision/race condition with another
+                # run, which is particularly suspicious for STANDARD provisioning.
+                self.log.warning(...)
                 self.log.warning(
                     f"Instance {instance_name} already exists with status "
                     f"{status} (a prior insert is still in flight) instead of "
@@ -442,9 +430,9 @@ class GCEHook(GoogleBaseHook):
                         instance_name, timeout_seconds=wait_timeout
                     )
                 return False
-            # Stale instance left over from a previous failed/expired attempt
-            # (e.g. a flex-start request that reached a terminal state before
-            # this retry) - delete it so the retry can submit a fresh insert.
+
+            # Clear any stale, terminally-failed instance from a previous run
+            # to allow a clean, fresh insertion on retry.
             self.log.warning(
                 f"Instance {instance_name} exists in terminal state {status}; "
                 "deleting before retrying."
@@ -455,10 +443,9 @@ class GCEHook(GoogleBaseHook):
             f"Launching {instance_name} on compute engine (instance: {instance_type}, "
             f"provisioning_model: {provisioning_model})"
         )
-        # For STANDARD/preemptible VMs the insert operation completes only once the
-        # VM is provisioned, so we wait on it. FLEX_START inserts are async: the
-        # request is queued by DWS and the VM sits in PENDING until capacity is
-        # found, so we submit without waiting and poll the instance status instead.
+
+        # Wait for STANDARD/preemptible insertions synchronously. FLEX_START
+        # inserts are async queue placements, so we submit immediately and poll.
         self.__create_instance(
             instance_type,
             instance_name,
@@ -559,10 +546,8 @@ class GCEHook(GoogleBaseHook):
         """Set the scheduling (and, for flex-start, params/reservation) block."""
         provisioning_model = (provisioning_model or "STANDARD").upper()
 
-        # Consume a specific (future) reservation: capacity is already secured,
-        # so we run STANDARD and target the reservation by name. This is mutually
-        # exclusive with FLEX_START/DWS, which queues for on-demand capacity and
-        # requires NO_RESERVATION.
+        # Target a specific reservation using STANDARD provisioning where capacity is
+        # pre-secured. This is mutually exclusive with FLEX_START queueing.
         if reservation_name:
             if provisioning_model == "FLEX_START":
                 raise AirflowException(
@@ -585,10 +570,9 @@ class GCEHook(GoogleBaseHook):
                 config["scheduling"]["preemptible"] = True
             return
 
-        # Flex-start (DWS) queues the request until GPU capacity is available
-        # instead of failing immediately on a stockout. It requires a max run
-        # duration and consumes preemptible quota; it is mutually exclusive with
-        # the preemptible flag.
+        # FLEX_START queues the request via DWS until capacity is available.
+        # It requires a max run duration and consumes preemptible quota, but
+        # cannot be combined with the explicit preemptible flag.
         if preemptible:
             raise AirflowException(
                 "preemptible=True is incompatible with FLEX_START provisioning."

--- a/orchestration/dags/common/hooks/gce.py
+++ b/orchestration/dags/common/hooks/gce.py
@@ -476,9 +476,7 @@ class GCEHook(GoogleBaseHook):
             # Cover the max queue wait plus provisioning/boot margin, mirroring
             # the deadline the deferrable path gives GCEInstanceRunningTrigger,
             # so this synchronous wait doesn't loop forever on a stuck instance.
-            self.wait_for_instance_running(
-                instance_name, timeout_seconds=wait_timeout
-            )
+            self.wait_for_instance_running(instance_name, timeout_seconds=wait_timeout)
         return False
 
     def wait_for_instance_running(

--- a/orchestration/dags/common/operators/gce.py
+++ b/orchestration/dags/common/operators/gce.py
@@ -1,4 +1,5 @@
 import subprocess
+import time
 import typing as t
 from datetime import datetime
 
@@ -21,6 +22,7 @@ from common.hooks.image import MACHINE_TYPE
 from common.hooks.network import BASE_NETWORK_LIST, GKE_NETWORK_LIST
 from common.triggers.gce import (
     DeferrableSSHJobMonitorTrigger,
+    GCEInstanceRunningTrigger,
 )
 
 
@@ -88,6 +90,8 @@ class StartGCEOperator(BaseOperator):
         "max_run_duration",
         "request_valid_for_duration",
         "reservation_name",
+        "deferrable",
+        "poll_interval",
     ]
 
     def __init__(
@@ -106,6 +110,8 @@ class StartGCEOperator(BaseOperator):
         max_run_duration: t.Union[str, int, None] = None,
         request_valid_for_duration: t.Union[str, int, None] = None,
         reservation_name: t.Optional[str] = None,
+        deferrable: bool = True,
+        poll_interval: int = 180,
         *args,
         **kwargs,
     ):
@@ -124,6 +130,13 @@ class StartGCEOperator(BaseOperator):
         self.max_run_duration = max_run_duration
         self.request_valid_for_duration = request_valid_for_duration
         self.reservation_name = reservation_name
+        # deferrable only affects FLEX_START requests: Defaults to True; set False to force the old
+        # synchronous wait. If a caller sets execution_timeout on this task,
+        # size it comfortably above request_valid_for_duration (max 2h) plus
+        # boot margin, since the trigger's own deadline is a separate,
+        # independent bound on the same wait.
+        self.deferrable = deferrable
+        self.poll_interval = poll_interval
 
     def execute(self, context) -> None:
         self.gpu_count = int(self.gpu_count)
@@ -131,6 +144,7 @@ class StartGCEOperator(BaseOperator):
         gce_networks = (
             GKE_NETWORK_LIST if self.use_gke_network is True else BASE_NETWORK_LIST
         )
+        is_flex_start = (self.provisioning_model or "STANDARD").upper() == "FLEX_START"
         max_run_seconds = parse_duration_to_seconds(self.max_run_duration)
         request_valid_seconds = parse_duration_to_seconds(
             self.request_valid_for_duration
@@ -142,10 +156,11 @@ class StartGCEOperator(BaseOperator):
             gce_zone=self.gce_zone,
             additional_scopes=self.additional_scopes,
         ) as hook:
-            # start_vm blocks until the VM is RUNNING. For a FLEX_START request
-            # that means the task stays occupied while DWS keeps the request
-            # queued in PENDING until GPU capacity is found.
-            hook.start_vm(
+            # For a deferrable FLEX_START (the default) we submit the (async,
+            # queued) insert and hand off polling to the trigger below so the
+            # worker slot is freed while the VM is PENDING. Otherwise start_vm
+            # blocks until the VM is RUNNING.
+            already_running = hook.start_vm(
                 self.instance_name,
                 self.instance_type,
                 preemptible=self.preemptible,
@@ -156,8 +171,52 @@ class StartGCEOperator(BaseOperator):
                 max_run_duration_seconds=max_run_seconds,
                 request_valid_for_duration_seconds=request_valid_seconds,
                 reservation_name=_clean_optional_template(self.reservation_name),
-                wait_for_running=True,
+                wait_for_running=not (is_flex_start and self.deferrable),
             )
+
+        if is_flex_start and self.deferrable and not already_running:
+            # Always bound the trigger by GCP's hard queue-wait cap (not the
+            # specific request_valid_for_duration configured for this request):
+            # DWS itself already enforces the configured value and terminates/
+            # deletes the instance when it elapses without securing capacity,
+            # which the trigger detects via the terminal-state/instance-gone
+            # checks. This deadline is a separate, independent worst-case
+            # backstop, so it shouldn't be tighter than what GCP could ever
+            # legitimately take, regardless of the configured value. Stored as
+            # an absolute deadline (not a relative timeout) so it survives a
+            # triggerer restart, which re-instantiates the trigger from
+            # `serialize()` and would otherwise silently reset a relative-
+            # duration countdown.
+            deadline = (
+                time.time()
+                + GCEHook.FLEX_START_MAX_QUEUE_SECONDS
+                + GCEHook.BOOT_MARGIN_SECONDS
+            )
+            self.log.info(
+                f"Flex-start request for {self.instance_name} submitted; deferring "
+                "until the instance reaches RUNNING."
+            )
+            self.defer(
+                trigger=GCEInstanceRunningTrigger(
+                    instance_name=self.instance_name,
+                    zone=self.gce_zone,
+                    poll_interval=self.poll_interval,
+                    deadline=deadline,
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(
+        self, context: t.Dict[str, t.Any], event: t.Optional[t.Dict[str, t.Any]] = None
+    ) -> None:
+        if event is None:
+            raise AirflowException("No event received in trigger callback")
+        if event.get("status") == "running_ok":
+            self.log.info(f"Instance {event.get('instance')} is RUNNING.")
+            return
+        raise AirflowException(
+            event.get("message", "Flex-start instance failed to start")
+        )
 
 
 class CleanGCEOperator(BaseOperator):

--- a/orchestration/dags/common/operators/gce.py
+++ b/orchestration/dags/common/operators/gce.py
@@ -110,6 +110,7 @@ class StartGCEOperator(BaseOperator):
         max_run_duration: t.Union[str, int, None] = None,
         request_valid_for_duration: t.Union[str, int, None] = None,
         reservation_name: t.Optional[str] = None,
+        # deferrable only affects FLEX_START requests: Defaults to True
         deferrable: bool = True,
         poll_interval: int = 180,
         *args,
@@ -130,11 +131,6 @@ class StartGCEOperator(BaseOperator):
         self.max_run_duration = max_run_duration
         self.request_valid_for_duration = request_valid_for_duration
         self.reservation_name = reservation_name
-        # deferrable only affects FLEX_START requests: Defaults to True; set False to force the old
-        # synchronous wait. If a caller sets execution_timeout on this task,
-        # size it comfortably above request_valid_for_duration (max 2h) plus
-        # boot margin, since the trigger's own deadline is a separate,
-        # independent bound on the same wait.
         self.deferrable = deferrable
         self.poll_interval = poll_interval
 
@@ -156,10 +152,8 @@ class StartGCEOperator(BaseOperator):
             gce_zone=self.gce_zone,
             additional_scopes=self.additional_scopes,
         ) as hook:
-            # For a deferrable FLEX_START (the default) we submit the (async,
-            # queued) insert and hand off polling to the trigger below so the
-            # worker slot is freed while the VM is PENDING. Otherwise start_vm
-            # blocks until the VM is RUNNING.
+            # For deferrable FLEX_START, submit asynchronously and hand off to the trigger
+            # to free the worker slot. Otherwise, start_vm blocks until the VM is RUNNING.
             already_running = hook.start_vm(
                 self.instance_name,
                 self.instance_type,
@@ -175,18 +169,9 @@ class StartGCEOperator(BaseOperator):
             )
 
         if is_flex_start and self.deferrable and not already_running:
-            # Always bound the trigger by GCP's hard queue-wait cap (not the
-            # specific request_valid_for_duration configured for this request):
-            # DWS itself already enforces the configured value and terminates/
-            # deletes the instance when it elapses without securing capacity,
-            # which the trigger detects via the terminal-state/instance-gone
-            # checks. This deadline is a separate, independent worst-case
-            # backstop, so it shouldn't be tighter than what GCP could ever
-            # legitimately take, regardless of the configured value. Stored as
-            # an absolute deadline (not a relative timeout) so it survives a
-            # triggerer restart, which re-instantiates the trigger from
-            # `serialize()` and would otherwise silently reset a relative-
-            # duration countdown.
+            # Set an absolute deadline as a worst-case backstop using GCP's hard queue cap.
+            # DWS handles the requested timeout natively, while the absolute timestamp
+            # ensures the timeout survives triggerer restarts without resetting.
             deadline = (
                 time.time()
                 + GCEHook.FLEX_START_MAX_QUEUE_SECONDS

--- a/orchestration/dags/common/triggers/gce.py
+++ b/orchestration/dags/common/triggers/gce.py
@@ -1,7 +1,7 @@
 import asyncio
-from typing import Any, Dict, Tuple
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, Tuple
 
 from airflow.providers.google.cloud.hooks.compute_ssh import ComputeEngineSSHHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
@@ -69,7 +69,10 @@ class GCEInstanceRunningTrigger(BaseTrigger):
                         executor, hook.get_instance, self.instance_name
                     )
                 except HttpError as exc:
-                    if exc.resp is not None and exc.resp.status in self.FATAL_HTTP_STATUSES:
+                    if (
+                        exc.resp is not None
+                        and exc.resp.status in self.FATAL_HTTP_STATUSES
+                    ):
                         yield TriggerEvent(
                             {
                                 "status": "error",

--- a/orchestration/dags/common/triggers/gce.py
+++ b/orchestration/dags/common/triggers/gce.py
@@ -49,17 +49,83 @@ class GCEInstanceRunningTrigger(BaseTrigger):
             },
         )
 
+    def _handle_http_error(self, exc) -> TriggerEvent | None:
+        """Handles HTTP errors during polling, distinguishing between fatal and transient errors."""
+        if exc.resp is not None and exc.resp.status in self.FATAL_HTTP_STATUSES:
+            return TriggerEvent(
+                {
+                    "status": "error",
+                    "instance": self.instance_name,
+                    "message": f"Failed to check status of {self.instance_name}: {exc}",
+                }
+            )
+
+        self.log.warning(
+            f"Transient error checking {self.instance_name} status: {exc}. Retrying."
+        )
+        if time.time() > self.deadline:
+            return TriggerEvent(
+                {
+                    "status": "error",
+                    "instance": self.instance_name,
+                    "message": (
+                        f"Timed out waiting for {self.instance_name} to "
+                        "reach RUNNING (last check failed with a transient error)."
+                    ),
+                }
+            )
+        return None
+
+    def _evaluate_status(self, instance) -> TriggerEvent | None:
+        """Evaluates the state of the GCE instance and returns a TriggerEvent if terminal."""
+        if instance is None:
+            return TriggerEvent(
+                {
+                    "status": "error",
+                    "instance": self.instance_name,
+                    "message": (
+                        f"Instance {self.instance_name} no longer exists: the "
+                        "flex-start request likely expired without securing capacity."
+                    ),
+                }
+            )
+
+        status = instance.get("status")
+        self.log.info(f"Instance {self.instance_name} status: {status}")
+
+        if status == "RUNNING":
+            return TriggerEvent(
+                {"status": "running_ok", "instance": self.instance_name}
+            )
+
+        if status in self.TERMINAL_STATES:
+            return TriggerEvent(
+                {
+                    "status": "error",
+                    "instance": self.instance_name,
+                    "message": (
+                        f"Instance {self.instance_name} reached terminal state "
+                        f"{status} before RUNNING; flex-start failed to secure capacity."
+                    ),
+                }
+            )
+
+        if time.time() > self.deadline:
+            return TriggerEvent(
+                {
+                    "status": "error",
+                    "instance": self.instance_name,
+                    "message": f"Timed out waiting for {self.instance_name} to reach RUNNING (last status: {status}).",
+                }
+            )
+        return None
+
     async def run(self):
         loop = asyncio.get_event_loop()
-        # Build the hook once, outside the poll loop: constructing GCEHook
-        # resolves credentials/discovery docs, which is wasted work (and a
-        # possible source of transient errors) if repeated every poll tick.
-        # The underlying httplib2/googleapiclient transport is NOT thread-safe,
-        # and the triggerer's default executor is a shared, multi-threaded pool
-        # used by every concurrently-running trigger in the process — so a
-        # single reused hook must be pinned to one dedicated worker thread,
-        # otherwise different poll ticks can land on different threads and
-        # crash the whole triggerer process (observed as a native.
+
+        # Build the hook once. Because the underlying googleapiclient transport is
+        # thread-unsafe, we pin it to a dedicated single-threaded executor to
+        # prevent cross-thread access and native crashes in the shared triggerer pool.
         hook = GCEHook(gce_zone=self.zone)
         executor = ThreadPoolExecutor(max_workers=1)
         try:
@@ -69,87 +135,16 @@ class GCEInstanceRunningTrigger(BaseTrigger):
                         executor, hook.get_instance, self.instance_name
                     )
                 except HttpError as exc:
-                    if (
-                        exc.resp is not None
-                        and exc.resp.status in self.FATAL_HTTP_STATUSES
-                    ):
-                        yield TriggerEvent(
-                            {
-                                "status": "error",
-                                "instance": self.instance_name,
-                                "message": (
-                                    f"Failed to check status of {self.instance_name}: "
-                                    f"{exc}"
-                                ),
-                            }
-                        )
-                        return
-                    self.log.warning(
-                        f"Transient error checking {self.instance_name} status: "
-                        f"{exc}. Retrying."
-                    )
-                    if time.time() > self.deadline:
-                        yield TriggerEvent(
-                            {
-                                "status": "error",
-                                "instance": self.instance_name,
-                                "message": (
-                                    f"Timed out waiting for {self.instance_name} to "
-                                    "reach RUNNING (last check failed with a transient "
-                                    "error)."
-                                ),
-                            }
-                        )
+                    event = self._handle_http_error(exc)
+                    if event:
+                        yield event
                         return
                     await asyncio.sleep(self.poll_interval)
                     continue
 
-                if instance is None:
-                    yield TriggerEvent(
-                        {
-                            "status": "error",
-                            "instance": self.instance_name,
-                            "message": (
-                                f"Instance {self.instance_name} no longer exists: the "
-                                "flex-start request likely expired without securing "
-                                "capacity."
-                            ),
-                        }
-                    )
-                    return
-
-                status = instance.get("status")
-                self.log.info(f"Instance {self.instance_name} status: {status}")
-
-                if status == "RUNNING":
-                    yield TriggerEvent(
-                        {"status": "running_ok", "instance": self.instance_name}
-                    )
-                    return
-                if status in self.TERMINAL_STATES:
-                    yield TriggerEvent(
-                        {
-                            "status": "error",
-                            "instance": self.instance_name,
-                            "message": (
-                                f"Instance {self.instance_name} reached terminal state "
-                                f"{status} before RUNNING; flex-start failed to secure "
-                                "capacity."
-                            ),
-                        }
-                    )
-                    return
-                if time.time() > self.deadline:
-                    yield TriggerEvent(
-                        {
-                            "status": "error",
-                            "instance": self.instance_name,
-                            "message": (
-                                f"Timed out waiting for {self.instance_name} to reach "
-                                f"RUNNING (last status: {status})."
-                            ),
-                        }
-                    )
+                event = self._evaluate_status(instance)
+                if event:
+                    yield event
                     return
 
                 await asyncio.sleep(self.poll_interval)

--- a/orchestration/dags/common/triggers/gce.py
+++ b/orchestration/dags/common/triggers/gce.py
@@ -1,10 +1,158 @@
 import asyncio
 from typing import Any, Dict, Tuple
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 from airflow.providers.google.cloud.hooks.compute_ssh import ComputeEngineSSHHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from common.config import GCP_PROJECT_ID, SSH_USER, USE_INTERNAL_IP
-from common.hooks.gce import DeferrableSSHGCEJobManager
+from common.hooks.gce import DeferrableSSHGCEJobManager, GCEHook
+from googleapiclient.errors import HttpError
+
+
+class GCEInstanceRunningTrigger(BaseTrigger):
+    """Polls a (flex-start) GCE instance until it reaches RUNNING.
+
+    Used by the deferrable ``StartGCEOperator`` so the Airflow worker slot is
+    freed while a DWS flex-start request sits queued in PENDING waiting for GPU
+    capacity (which can take up to the configured ``request_valid_for_duration``,
+    max 2h).
+    """
+
+    TERMINAL_STATES = GCEHook.TERMINAL_STATES
+    FATAL_HTTP_STATUSES = {401, 403}
+
+    def __init__(
+        self,
+        instance_name: str,
+        zone: str,
+        poll_interval: int = 120,
+        deadline: float = 0.0,
+    ):
+        super().__init__()
+        self.instance_name = instance_name
+        self.zone = zone
+        self.poll_interval = poll_interval
+        # Absolute epoch deadline (not a relative timeout): this survives a
+        # triggerer restart, which re-instantiates the trigger from `serialize()`
+        # and would otherwise silently reset a relative-duration countdown.
+        self.deadline = deadline
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        return (
+            self.__class__.__module__ + "." + self.__class__.__name__,
+            {
+                "instance_name": self.instance_name,
+                "zone": self.zone,
+                "poll_interval": self.poll_interval,
+                "deadline": self.deadline,
+            },
+        )
+
+    async def run(self):
+        loop = asyncio.get_event_loop()
+        # Build the hook once, outside the poll loop: constructing GCEHook
+        # resolves credentials/discovery docs, which is wasted work (and a
+        # possible source of transient errors) if repeated every poll tick.
+        # The underlying httplib2/googleapiclient transport is NOT thread-safe,
+        # and the triggerer's default executor is a shared, multi-threaded pool
+        # used by every concurrently-running trigger in the process — so a
+        # single reused hook must be pinned to one dedicated worker thread,
+        # otherwise different poll ticks can land on different threads and
+        # crash the whole triggerer process (observed as a native.
+        hook = GCEHook(gce_zone=self.zone)
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            while True:
+                try:
+                    instance = await loop.run_in_executor(
+                        executor, hook.get_instance, self.instance_name
+                    )
+                except HttpError as exc:
+                    if exc.resp is not None and exc.resp.status in self.FATAL_HTTP_STATUSES:
+                        yield TriggerEvent(
+                            {
+                                "status": "error",
+                                "instance": self.instance_name,
+                                "message": (
+                                    f"Failed to check status of {self.instance_name}: "
+                                    f"{exc}"
+                                ),
+                            }
+                        )
+                        return
+                    self.log.warning(
+                        f"Transient error checking {self.instance_name} status: "
+                        f"{exc}. Retrying."
+                    )
+                    if time.time() > self.deadline:
+                        yield TriggerEvent(
+                            {
+                                "status": "error",
+                                "instance": self.instance_name,
+                                "message": (
+                                    f"Timed out waiting for {self.instance_name} to "
+                                    "reach RUNNING (last check failed with a transient "
+                                    "error)."
+                                ),
+                            }
+                        )
+                        return
+                    await asyncio.sleep(self.poll_interval)
+                    continue
+
+                if instance is None:
+                    yield TriggerEvent(
+                        {
+                            "status": "error",
+                            "instance": self.instance_name,
+                            "message": (
+                                f"Instance {self.instance_name} no longer exists: the "
+                                "flex-start request likely expired without securing "
+                                "capacity."
+                            ),
+                        }
+                    )
+                    return
+
+                status = instance.get("status")
+                self.log.info(f"Instance {self.instance_name} status: {status}")
+
+                if status == "RUNNING":
+                    yield TriggerEvent(
+                        {"status": "running_ok", "instance": self.instance_name}
+                    )
+                    return
+                if status in self.TERMINAL_STATES:
+                    yield TriggerEvent(
+                        {
+                            "status": "error",
+                            "instance": self.instance_name,
+                            "message": (
+                                f"Instance {self.instance_name} reached terminal state "
+                                f"{status} before RUNNING; flex-start failed to secure "
+                                "capacity."
+                            ),
+                        }
+                    )
+                    return
+                if time.time() > self.deadline:
+                    yield TriggerEvent(
+                        {
+                            "status": "error",
+                            "instance": self.instance_name,
+                            "message": (
+                                f"Timed out waiting for {self.instance_name} to reach "
+                                f"RUNNING (last status: {status})."
+                            ),
+                        }
+                    )
+                    return
+
+                await asyncio.sleep(self.poll_interval)
+        finally:
+            hook.close()
+            executor.shutdown(wait=False)
 
 
 class DeferrableSSHJobMonitorTrigger(BaseTrigger):

--- a/orchestration/dags/jobs/administration/gcp_launch_vm.py
+++ b/orchestration/dags/jobs/administration/gcp_launch_vm.py
@@ -63,7 +63,7 @@ DAG_DOC = """
       available instead of failing on stockout — handy for GPUs that frequently stock out.
       With FLEX_START you must set `max_run_duration` (the VM is auto-deleted after it), and
       `request_valid_for_duration` controls how long the request stays queued (max 2h). The
-      task does not defer while the request is queued.
+      task defers (frees its worker slot) while the request is queued.
       FLEX_START is incompatible with `reservation_name` and preemptible.
     * reservation_name: if you have a specific Compute Engine reservation to consume, set this parameter to the name of the reservation. When set, the VM targets this reservation via SPECIFIC_RESERVATION and requires provisioning_model=STANDARD (incompatible with FLEX_START). The instance_type, gpu_type, gpu_count and gce_zone must match the reservation exactly. Leave empty to not target any reservation.
     * use_gke_network: if you need your VM to comminicate with the Clickhouse cluster, set this parameter to True

--- a/orchestration/dags/jobs/ml/item_embedding.py
+++ b/orchestration/dags/jobs/ml/item_embedding.py
@@ -207,7 +207,9 @@ with DAG(
         max_run_duration="{{ params.max_run_duration }}",
         request_valid_for_duration="{{ params.request_valid_for_duration }}",
         reservation_name="{{ params.reservation_name }}",
-        # cover the max 2h queue wait plus provisioning/boot margin.
+        # A FLEX_START request always defers while DWS keeps it queued, freeing
+        # the worker slot; cover the max 2h queue wait plus provisioning/boot
+        # margin regardless.
         execution_timeout=timedelta(hours=3),
         retries=3,
     )


### PR DESCRIPTION
# DE PR

## Summary

`StartGCEOperator` currently blocks an Airflow worker slot for the entire time
a `FLEX_START` (Dynamic Workload Scheduler) VM request sits queued waiting for
GPU capacity — up to `request_valid_for_duration` (max 2h) plus boot margin.
This PR makes that wait deferrable by default: the task frees its worker slot
and a new trigger polls instance status on the triggerer instead, resuming the
task once the VM reaches `RUNNING`.
Please include a summary of the changes:

## Changes

- **`common/hooks/gce.py` — `start_vm` is now idempotent against retries.**
  Previously only recognized `status == "RUNNING"` as "already handled"; a
  retry after a crash mid-insert would 409. Now adopts any non-terminal
  existing instance, deletes-and-recreates on terminal states, returns `bool`.
  *Trade-off:* adoption doesn't verify ownership (`instance_name` is the only
  key) — a second unrelated run sharing that name could collide. Mitigated
  with a `warning` log flagging the possible race, not fixed. Also bounded the
  previously-unbounded synchronous wait and added the missing `STOPPED`
  terminal state.
- **`common/triggers/gce.py` — new `GCEInstanceRunningTrigger`.** Polls until
  `RUNNING`/terminal/404/deadline. Fixes vs. the reverted version: absolute
  epoch deadline instead of a relative timeout (survived triggerer restarts
  incorrectly before), fail-fast on `401`/`403` instead of retrying silently,
  and single-thread-pinned polling (an earlier draft shared the triggerer's
  thread pool, which crashed the whole process since `httplib2` isn't
  thread-safe).
- **`common/operators/gce.py` — wires it in.** `deferrable: bool = True`,
  `poll_interval: int = 60`. Defers only for `FLEX_START` + not already
  running; `deferrable=False` keeps the old synchronous path. Trigger deadline
  uses GCP's fixed 2h queue cap + 15min margin, not the caller's specific
  `request_valid_for_duration`.

## Review guide

1. `hooks/gce.py` `start_vm`/`wait_for_instance_running` — the 3-way status
   branch is the foundation everything else assumes.
2. `triggers/gce.py` `GCEInstanceRunningTrigger.run()` — confirm every GCE
   call goes through the dedicated single-thread executor, and `401`/`403`
   return immediately instead of retrying.
3. `operators/gce.py` `execute()` — confirm the `GCEHook` context manager
   closes before `self.defer()`, and walk the defer condition for
   `STANDARD` / `deferrable=False` / already-running cases.
4. `execute_complete` — only succeeds on `"running_ok"`, raises otherwise.

### Type of change

* [ ] Fix (non-breaking change which corrects expected behavior)
* [ ] New fields (non-breaking change)
* [ ] New table (non-breaking change)
* [ ] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts)
* [ ] Table deletion (potentially breaking change which adds functionality/ table)

### Checklist before requesting a review

* [ ] I have performed a self-review of my code

* [ ] My code passes CI/CD tests
* [ ] I updated README.md
* [ ] I have updated the dag
* [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
* [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?

* [ ] 👍 yes
* [ ] 🙅 no, because they aren't needed
* [ ] 🙋 no, because I need help
* [ ] ⏰ no, but I created a ticket

### PR title format (except for MEP)

There is a linter on the PR title format. Please respect the following format:

<details>
<summary>(ticket) type(topic): comment</summary>

* ticket surrounded by parenthesis, with optionnaly a hyphen followed by one or more digits (e.g., -1234). The first part must be one of the following strings:
  * DA
  * DE
  * AE
  * DS
  * HF
  * BSR
  * PC

* type :
The second part to specify the type of change one of the following :
  * build
  * lint
  * ci
  * docs
  * feat
  * fix
  * perf
  * refactor
  * test
  * chore
  * dbt

* topic within parenthesis: 1 word e.g., (dag)

* comment: tell us your life

examples:

* :white_check_mark: (DE-124) refactor(firebase): update source field
* :x: (DE-124) refactor (firebase): update source field **(space between type and topic)**
* :x: (DE-124) airflow(firebase): update source fiedd in DAG **(wrong type)**
* :x: (DE-124) (DE-124) refactor(firebase refacto): update source field **(topic in two words)**
* :white_check_mark: (BSR) docs(github): add PR title valid format in template

</details>
