### PR TITLE
(DE-3419) feat(embedding): enhance the embedding prompt system

### DIFF
--- a/jobs/ml_jobs/item_embedding/config.py
+++ b/jobs/ml_jobs/item_embedding/config.py
@@ -19,7 +19,7 @@ class Vector(BaseModel):
 
 
 def _load_config(config_file_name: str) -> dict:
-    """Load YAML configuration file.
+    """Load YAML configuration file of vectors to embed.
 
     Args:
         config_file_name: Name of the config file (without .yaml extension)

--- a/jobs/ml_jobs/item_embedding/config.py
+++ b/jobs/ml_jobs/item_embedding/config.py
@@ -15,6 +15,7 @@ class Vector(BaseModel):
     features: list[str]
     encoder_name: str
     prompt_name: Optional[str] = None
+    labels: dict[str, str] = {}
 
 
 def _load_config(config_file_name: str) -> dict:

--- a/jobs/ml_jobs/item_embedding/configs/default.yaml
+++ b/jobs/ml_jobs/item_embedding/configs/default.yaml
@@ -10,8 +10,6 @@
 # ['query', 'document', 'BitextMining', 'Clustering', 'Classification',
 # 'InstructionRetrieval', 'MultilabelClassification', 'PairClassification',
 # 'Reranking', 'Retrieval', 'Retrieval-query', 'Retrieval-document', 'STS', 'Summarization'].
-# 'query' applies the retrieval "search result" instruction:
-#   "task: search result | query: {content}"
 # (see https://huggingface.co/google/embeddinggemma-300m)
 
 vectors:
@@ -24,7 +22,7 @@ vectors:
       - author_concat
       - offer_description
     encoder_name: "google/embeddinggemma-300m"
-    prompt_name: "query"
+    prompt_name: "document"  # "document" prompt: "title: none | text: {content}"
 
   # - name: "image_content"
   #   features:

--- a/jobs/ml_jobs/item_embedding/configs/default.yaml
+++ b/jobs/ml_jobs/item_embedding/configs/default.yaml
@@ -2,11 +2,13 @@
 # Each vector defines which features to include in the embedding prompt and the model to use for embedding extraction
 
 # Features will be concatenated in the order specified for each vector type
+# Feature may have an optional label override in the "labels" section, which will be used in the prompt instead of the column name
 # e.g. the "semantic_content" vector will encode:
-    # subcategory_id : <subcategory_id_value>
-    # offer_name : <offer_name_value>
+    # titre de l'offre : <offer_name_value>
+    # catégorie : <category_id_value>
 # into a single prompt for embedding extraction
-## available prompt_names for embeddinggemma:
+
+## Available prompt_names for embeddinggemma:
 # ['query', 'document', 'BitextMining', 'Clustering', 'Classification',
 # 'InstructionRetrieval', 'MultilabelClassification', 'PairClassification',
 # 'Reranking', 'Retrieval', 'Retrieval-query', 'Retrieval-document', 'STS', 'Summarization'].
@@ -23,6 +25,14 @@ vectors:
       - offer_description
     encoder_name: "google/embeddinggemma-300m"
     prompt_name: "document"  # "document" prompt: "title: none | text: {content}"
+    labels:
+      offer_name: "titre de l'offre"
+      category_id: "catégorie"
+      subcategory_id: "sous-catégorie"
+      offer_label_concat: "genres"
+      author_concat: "auteur/artiste"
+      offer_description: "description"
+
 
   # - name: "image_content"
   #   features:

--- a/jobs/ml_jobs/item_embedding/embedding.py
+++ b/jobs/ml_jobs/item_embedding/embedding.py
@@ -9,10 +9,12 @@ from sentence_transformers import SentenceTransformer
 def _build_prompts(df: pd.DataFrame, vector: Vector) -> list[str]:
     """Build text prompts for all rows using vectorized operations.
 
-    Concatenates non-null feature values as ``"feature : value"`` pairs
-    separated by newlines. Features with null values are omitted entirely.
-    Rows where all features are null produce an empty string and are logged
-    as a warning.
+    Concatenates non-null feature values as ``"label : value"`` pairs
+    separated by newlines.
+    The label defaults to the column name unless overridden in vector.labels.
+    Features with null values are omitted entirely.
+    Items with all-null features will have an empty prompt string and are logged as a warning.
+    They will later receive a ``None`` embedding without calling the model.
 
     Args:
         df: DataFrame with item metadata
@@ -21,12 +23,12 @@ def _build_prompts(df: pd.DataFrame, vector: Vector) -> list[str]:
     Returns:
         List of formatted prompt strings, one per row
     """
-    # Format each feature as "feature : value"; omit entirely if null or empty
     parts = []
     for feature in vector.features:
+        label = vector.labels.get(feature, feature)
         mask = df[feature].notna() & (df[feature].astype(str).str.strip() != "")
         formatted = pd.Series("", index=df.index)
-        formatted[mask] = feature + " : " + df[feature][mask].astype(str)
+        formatted[mask] = label + " : " + df[feature][mask].astype(str)
         parts.append(formatted)
 
     # Join non-null parts per row with a newline (null features are omitted)
@@ -70,8 +72,6 @@ def embed_vector(
         "show_progress_bar": False,
         "batch_size": BATCH_SIZE,
         "prompt_name": vector.prompt_name,
-        # L2-normalize so cosine similarity, dot-product indexes and
-        # Euclidean/k-means clustering all behave consistently downstream.
         "normalize_embeddings": True,
     }
 
@@ -93,6 +93,7 @@ def embed_dataframe(
     pools: dict[str, object] = None,
 ) -> pd.DataFrame:
     """Compute all vector embeddings for a dataframe.
+    Empty prompts are skipped and receive ``None`` for that vector.
 
     Args:
         df: DataFrame with item metadata (must contain 'item_id', 'content_hash' and all feature columns)
@@ -110,13 +111,16 @@ def embed_dataframe(
     pools = pools or {}
     logger.info(f"Embedding {len(df)} items")
 
-    # Cache prompts by feature tuple to avoid re-building identical text
-    prompts_cache: dict[tuple[str, ...], list[str]] = {}
+    # Cache prompts by (features, labels) to avoid re-building identical text
+    prompts_cache: dict[
+        tuple[tuple[str, ...], tuple[tuple[str, str], ...]], list[str]
+    ] = {}
 
     df_embeddings = df[["item_id", "content_hash"]].copy()
 
     for vector in vectors:
-        features_key = tuple(vector.features)
+        # Prompt text depends on both the columns and their labels.
+        features_key = (tuple(vector.features), tuple(sorted(vector.labels.items())))
         if features_key not in prompts_cache:
             prompts_cache[features_key] = _build_prompts(df, vector)
         else:

--- a/jobs/ml_jobs/item_embedding/embedding.py
+++ b/jobs/ml_jobs/item_embedding/embedding.py
@@ -104,7 +104,8 @@ def embed_dataframe(
 
     Returns:
         DataFrame with 'item_id', 'content_hash', and one column per vector.
-        Each vector column contains embedding arrays.
+        Each vector column contains embedding arrays. Rows whose features are
+        all null get ``None`` for that vector instead of an embedding.
     """
     pools = pools or {}
     logger.info(f"Embedding {len(df)} items")
@@ -124,13 +125,27 @@ def embed_dataframe(
                 f"(same features as a previous vector)"
             )
 
-        vector_embeddings = embed_vector(
-            vector,
-            encoders[vector.encoder_name],
-            prompts=prompts_cache[features_key],
-            pool=pools.get(vector.encoder_name),
-        )
+        prompts = prompts_cache[features_key]
+        # Skip all-null rows (empty prompt): don't embed the bare instruction.
+        keep_mask = [bool(prompt) for prompt in prompts]
+        non_empty_prompts = [prompt for prompt, keep in zip(prompts, keep_mask) if keep]
 
-        df_embeddings[vector.name] = vector_embeddings.tolist()
+        if non_empty_prompts:
+            vector_embeddings = embed_vector(
+                vector,
+                encoders[vector.encoder_name],
+                prompts=non_empty_prompts,
+                pool=pools.get(vector.encoder_name),
+            )
+            embeddings_iter = iter(vector_embeddings.tolist())
+            column = [next(embeddings_iter) if keep else None for keep in keep_mask]
+        else:
+            logger.warning(
+                f"Vector '{vector.name}': all rows have empty prompts; "
+                f"writing None for every item."
+            )
+            column = [None] * len(prompts)
+
+        df_embeddings[vector.name] = column
 
     return df_embeddings

--- a/jobs/ml_jobs/item_embedding/embedding.py
+++ b/jobs/ml_jobs/item_embedding/embedding.py
@@ -70,6 +70,9 @@ def embed_vector(
         "show_progress_bar": False,
         "batch_size": BATCH_SIZE,
         "prompt_name": vector.prompt_name,
+        # L2-normalize so cosine similarity, dot-product indexes and
+        # Euclidean/k-means clustering all behave consistently downstream.
+        "normalize_embeddings": True,
     }
 
     if pool is not None:

--- a/jobs/ml_jobs/item_embedding/embedding.py
+++ b/jobs/ml_jobs/item_embedding/embedding.py
@@ -14,7 +14,7 @@ def _build_prompts(df: pd.DataFrame, vector: Vector) -> list[str]:
     The label defaults to the column name unless overridden in vector.labels.
     Features with null values are omitted entirely.
     Items with all-null features will have an empty prompt string and are logged as a warning.
-    They will later receive a ``None`` embedding without calling the model.
+    They are skipped entirely by the caller and excluded from the output (no null vectors).
 
     Args:
         df: DataFrame with item metadata
@@ -93,7 +93,11 @@ def embed_dataframe(
     pools: dict[str, object] = None,
 ) -> pd.DataFrame:
     """Compute all vector embeddings for a dataframe.
-    Empty prompts are skipped and receive ``None`` for that vector.
+
+    Items with no metadata to embed for one or more vectors (all-null features,
+    i.e. an empty prompt) are skipped entirely and logged, so every vector
+    column in the returned DataFrame is fully populated with real embeddings —
+    the output never contains null vectors.
 
     Args:
         df: DataFrame with item metadata (must contain 'item_id', 'content_hash' and all feature columns)
@@ -105,8 +109,8 @@ def embed_dataframe(
 
     Returns:
         DataFrame with 'item_id', 'content_hash', and one column per vector.
-        Each vector column contains embedding arrays. Rows whose features are
-        all null get ``None`` for that vector instead of an embedding.
+        Each vector column contains an embedding array for every row; items
+        lacking metadata for any vector are excluded from the result.
     """
     pools = pools or {}
     logger.info(f"Embedding {len(df)} items")
@@ -116,8 +120,7 @@ def embed_dataframe(
         tuple[tuple[str, ...], tuple[tuple[str, str], ...]], list[str]
     ] = {}
 
-    df_embeddings = df[["item_id", "content_hash"]].copy()
-
+    prompts_by_vector: dict[str, list[str]] = {}
     for vector in vectors:
         # Prompt text depends on both the columns and their labels.
         features_key = (tuple(vector.features), tuple(sorted(vector.labels.items())))
@@ -128,28 +131,45 @@ def embed_dataframe(
                 f"Vector '{vector.name}': reusing cached prompts "
                 f"(same features as a previous vector)"
             )
+        prompts_by_vector[vector.name] = prompts_cache[features_key]
 
-        prompts = prompts_cache[features_key]
-        # Skip all-null rows (empty prompt): don't embed the bare instruction.
-        keep_mask = [bool(prompt) for prompt in prompts]
-        non_empty_prompts = [prompt for prompt, keep in zip(prompts, keep_mask) if keep]
+    # Keep only items that have metadata for *every* vector (non-empty prompt),
+    # so no vector column ends up with a null embedding. An empty prompt means
+    # all of that vector's features are null for the item.
+    keep_mask = np.ones(len(df), dtype=bool)
+    for prompts in prompts_by_vector.values():
+        keep_mask &= np.array([bool(prompt) for prompt in prompts], dtype=bool)
 
-        if non_empty_prompts:
-            vector_embeddings = embed_vector(
-                vector,
-                encoders[vector.encoder_name],
-                prompts=non_empty_prompts,
-                pool=pools.get(vector.encoder_name),
-            )
-            embeddings_iter = iter(vector_embeddings.tolist())
-            column = [next(embeddings_iter) if keep else None for keep in keep_mask]
-        else:
-            logger.warning(
-                f"Vector '{vector.name}': all rows have empty prompts; "
-                f"writing None for every item."
-            )
-            column = [None] * len(prompts)
+    dropped_items = df.loc[~keep_mask, "item_id"].tolist()
+    if dropped_items:
+        logger.warning(
+            f"Skipping {len(dropped_items)} item(s) with no metadata to embed; "
+            f"they are excluded from the output. Item ids:\n{dropped_items}"
+        )
+    if not keep_mask.any():
+        logger.warning("No item has metadata to embed; returning an empty result.")
 
-        df_embeddings[vector.name] = column
+    df_embeddings = df.loc[keep_mask, ["item_id", "content_hash"]].reset_index(
+        drop=True
+    )
+
+    for vector in vectors:
+        prompts = [
+            prompt
+            for prompt, keep in zip(prompts_by_vector[vector.name], keep_mask)
+            if keep
+        ]
+        if not prompts:
+            df_embeddings[vector.name] = pd.Series(dtype=object)
+            continue
+
+        vector_embeddings = embed_vector(
+            vector,
+            encoders[vector.encoder_name],
+            prompts=prompts,
+            pool=pools.get(vector.encoder_name),
+        )
+        # Positional assignment: prompts and embeddings align with the kept rows.
+        df_embeddings[vector.name] = vector_embeddings.tolist()
 
     return df_embeddings

--- a/jobs/ml_jobs/item_embedding/embedding.py
+++ b/jobs/ml_jobs/item_embedding/embedding.py
@@ -12,16 +12,17 @@ def _build_prompts(df: pd.DataFrame, vector: Vector) -> list[str]:
     Concatenates non-null feature values as ``"label : value"`` pairs
     separated by newlines.
     The label defaults to the column name unless overridden in vector.labels.
-    Features with null values are omitted entirely.
-    Items with all-null features will have an empty prompt string and are logged as a warning.
-    They are skipped entirely by the caller and excluded from the output (no null vectors).
+    Features with null values are omitted entirely from the prompt string.
+    Items with all-null features get an empty prompt string (kept in place so
+    the result stays aligned row-for-row with ``df``) and are logged.
 
     Args:
         df: DataFrame with item metadata
         vector: Vector configuration
 
     Returns:
-        List of formatted prompt strings, one per row
+        List of formatted prompt strings, one per row (empty string for rows
+        whose features are all null).
     """
     parts = []
     for feature in vector.features:
@@ -36,11 +37,11 @@ def _build_prompts(df: pd.DataFrame, vector: Vector) -> list[str]:
         lambda row: "\n".join(filter(None, row)), axis=1
     )
 
-    empty_count = (combined == "").sum()
-    empty_items = df[(combined == "")].index
-    if empty_count > 0:
+    empty_items = df.index[combined == ""]
+    if len(empty_items) > 0:
         logger.warning(
-            f"Vector '{vector.name}': {empty_count} rows have all-null features.\n Empty items are:\n {list(empty_items)}"
+            f"Vector '{vector.name}': {len(empty_items)} rows have all-null "
+            f"features.\n Empty items are:\n {list(empty_items)}"
         )
 
     return combined.tolist()
@@ -96,11 +97,11 @@ def embed_dataframe(
 
     Items with no metadata to embed for one or more vectors (all-null features,
     i.e. an empty prompt) are skipped entirely and logged, so every vector
-    column in the returned DataFrame is fully populated with real embeddings —
-    the output never contains null vectors.
+    column in the returned DataFrame is fully populated with real embeddings (non-null vectors).
 
     Args:
-        df: DataFrame with item metadata (must contain 'item_id', 'content_hash' and all feature columns)
+        df: DataFrame with item metadata (must contain 'item_id', 'content_hash'
+            and all feature columns required by the vectors in the config file)
         vectors: Vector configurations
         encoders: Pre-loaded encoders keyed by encoder name
         pools: Pre-started multi-process pools keyed by encoder name. When a
@@ -115,50 +116,33 @@ def embed_dataframe(
     pools = pools or {}
     logger.info(f"Embedding {len(df)} items")
 
-    # Cache prompts by (features, labels) to avoid re-building identical text
-    prompts_cache: dict[
-        tuple[tuple[str, ...], tuple[tuple[str, str], ...]], list[str]
-    ] = {}
-
-    prompts_by_vector: dict[str, list[str]] = {}
+    # Put each vector's prompts in a column next to the item identifiers. Every
+    # column has one entry per input row, so item_id, content_hash and all
+    # prompts stay aligned on the same DataFrame row.
+    prompts_df = df[["item_id", "content_hash"]].reset_index(drop=True)
     for vector in vectors:
-        # Prompt text depends on both the columns and their labels.
-        features_key = (tuple(vector.features), tuple(sorted(vector.labels.items())))
-        if features_key not in prompts_cache:
-            prompts_cache[features_key] = _build_prompts(df, vector)
-        else:
-            logger.info(
-                f"Vector '{vector.name}': reusing cached prompts "
-                f"(same features as a previous vector)"
-            )
-        prompts_by_vector[vector.name] = prompts_cache[features_key]
+        prompts_df[vector.name] = _build_prompts(df, vector)
 
-    # Keep only items that have metadata for *every* vector (non-empty prompt),
-    # so no vector column ends up with a null embedding. An empty prompt means
-    # all of that vector's features are null for the item.
-    keep_mask = np.ones(len(df), dtype=bool)
-    for prompts in prompts_by_vector.values():
-        keep_mask &= np.array([bool(prompt) for prompt in prompts], dtype=bool)
+    # Keep only items that have a non-empty prompt for *every* vector, so no
+    # vector column ends up with a null embedding. An empty prompt means all of
+    # that vector's features are null for the item.
+    vector_names = [vector.name for vector in vectors]
+    complete = (prompts_df[vector_names] != "").all(axis=1)
 
-    dropped_items = df.loc[~keep_mask, "item_id"].tolist()
+    dropped_items = prompts_df.loc[~complete, "item_id"].tolist()
     if dropped_items:
         logger.warning(
             f"Skipping {len(dropped_items)} item(s) with no metadata to embed; "
             f"they are excluded from the output. Item ids:\n{dropped_items}"
         )
-    if not keep_mask.any():
+    if not complete.any():
         logger.warning("No item has metadata to embed; returning an empty result.")
 
-    df_embeddings = df.loc[keep_mask, ["item_id", "content_hash"]].reset_index(
-        drop=True
-    )
+    prompts_df = prompts_df[complete].reset_index(drop=True)
 
+    df_embeddings = prompts_df[["item_id", "content_hash"]].copy()
     for vector in vectors:
-        prompts = [
-            prompt
-            for prompt, keep in zip(prompts_by_vector[vector.name], keep_mask)
-            if keep
-        ]
+        prompts = prompts_df[vector.name].tolist()
         if not prompts:
             df_embeddings[vector.name] = pd.Series(dtype=object)
             continue
@@ -169,7 +153,6 @@ def embed_dataframe(
             prompts=prompts,
             pool=pools.get(vector.encoder_name),
         )
-        # Positional assignment: prompts and embeddings align with the kept rows.
         df_embeddings[vector.name] = vector_embeddings.tolist()
 
     return df_embeddings

--- a/jobs/ml_jobs/item_embedding/main.py
+++ b/jobs/ml_jobs/item_embedding/main.py
@@ -32,7 +32,7 @@ def main(
         help="Path to the output parquet folder on GCS where results will be saved",
     ),
 ) -> None:
-    """Main function to load item metadata, generate embeddings, and save results.
+    """Main function to load item metadata, generate embeddings, and save results as parquets.
 
     Args:
         config_file_name: Name of the configuration file (without .yaml extension)
@@ -45,7 +45,7 @@ def main(
         f"  Input parquets folder path: {input_parquets_folder_path}\n"
         f"  Output parquets folder path: {output_parquets_folder_path}"
     )
-    # Load configuration and vectors
+    # Load vectors configuration and encoder weights
     vectors = parse_vectors(config_file_name)
 
     gpu_count = _get_gpu_count()
@@ -57,7 +57,7 @@ def main(
     parquet_files = list_parquet_files(input_parquets_folder_path)
     logger.info(f"Found {len(parquet_files)} parquet files to process")
 
-    # Start multi-GPU pools once for the whole run (loads models onto GPUs once)
+    # Start multi-GPU pools once for the whole run if available
     pools = start_encoder_pools(encoders, gpu_count)
     try:
         for i, parquet_filepath in enumerate(parquet_files):
@@ -71,7 +71,7 @@ def main(
             logger.info(
                 f"Generated embeddings for {len(df_embeddings)} items from {parquet_filepath}"
             )
-            # Upload the resulting dataframe to GCS as a parquet file
+
             output_parquet_path = (
                 f"{output_parquets_folder_path}/item_embeddings_{i}.parquet"
             )
@@ -80,7 +80,7 @@ def main(
     finally:
         stop_encoder_pools(encoders, pools)
 
-    logger.info("✔ All parquet files processed successfully")
+    logger.info("✅ All parquet files processed successfully")
 
 
 if __name__ == "__main__":

--- a/jobs/ml_jobs/item_embedding/setup_encoders.py
+++ b/jobs/ml_jobs/item_embedding/setup_encoders.py
@@ -23,7 +23,7 @@ def _resolve_precision(gpu_count: int) -> torch.dtype:
         return torch.bfloat16
 
     logger.info("GPU does not support bfloat16 or no GPU: using float32 precision")
-    # return torch.float32
+    return torch.float32
 
 
 def _bf16_supported() -> bool:

--- a/jobs/ml_jobs/item_embedding/setup_encoders.py
+++ b/jobs/ml_jobs/item_embedding/setup_encoders.py
@@ -23,7 +23,7 @@ def _resolve_precision(gpu_count: int) -> torch.dtype:
         return torch.bfloat16
 
     logger.info("GPU does not support bfloat16 or no GPU: using float32 precision")
-    return torch.float32
+    # return torch.float32
 
 
 def _bf16_supported() -> bool:
@@ -48,8 +48,8 @@ def load_encoders(
     token = get_secret(HF_TOKEN_SECRET_NAME)
     precision = _resolve_precision(gpu_count)
 
-    # With >1 GPU, the multi-process pool loads a full model copy onto every GPU.
-    # Keep the main-process copy on CPU so GPU 0 does not hold two copies (OOM).
+    # With >1 GPU, the multi-process pool loads a full model copy onto **every** GPU.
+    # so we keep the main-process copy on CPU so GPU 0 does not hold two copies (risk of OOM).
     device = "cpu" if gpu_count > 1 else None
 
     encoders = {}
@@ -72,6 +72,7 @@ def start_encoder_pools(
     encoders: dict[str, SentenceTransformer], gpu_count: int
 ) -> dict[str, object]:
     """Start one multi-process encoding pool per encoder, once for the whole run.
+    If no GPUs are available, returns an empty dict (single-device encoding will be used).
 
     Args:
         encoders: Pre-loaded encoders keyed by encoder name

--- a/jobs/ml_jobs/item_embedding/tests/test_embedding.py
+++ b/jobs/ml_jobs/item_embedding/tests/test_embedding.py
@@ -150,6 +150,28 @@ class TestBuildPrompts:
         assert len(prompts) == 3
         assert prompts[1] == "x : b"
 
+    def test_labels_override_column_names(self):
+        df = pd.DataFrame({"offer_name": ["Dune"], "author_concat": ["Herbert"]})
+        vector = Vector(
+            name="test",
+            features=["offer_name", "author_concat"],
+            encoder_name="model",
+            labels={"offer_name": "titre", "author_concat": "auteur / artiste"},
+        )
+        prompts = _build_prompts(df, vector)
+        assert prompts == ["titre : Dune\nauteur / artiste : Herbert"]
+
+    def test_unmapped_feature_falls_back_to_column_name(self):
+        df = pd.DataFrame({"offer_name": ["Dune"], "category_id": ["LIVRE"]})
+        vector = Vector(
+            name="test",
+            features=["offer_name", "category_id"],
+            encoder_name="model",
+            labels={"offer_name": "titre"},
+        )
+        prompts = _build_prompts(df, vector)
+        assert prompts == ["titre : Dune\ncategory_id : LIVRE"]
+
 
 # ---------------------------------------------------------------------------
 # End-to-end embed_dataframe tests

--- a/jobs/ml_jobs/item_embedding/tests/test_embedding.py
+++ b/jobs/ml_jobs/item_embedding/tests/test_embedding.py
@@ -134,9 +134,18 @@ class TestBuildPrompts:
         assert prompts == ["x : hello"]
 
     def test_all_null_produces_empty_string(self):
+        # The empty prompt is kept in place so the result stays row-aligned
+        # with the input; embed_dataframe is what drops the item later.
         df = pd.DataFrame({"x": [None], "y": [None]})
         prompts = _build_prompts(df, self.make_vector(["x", "y"]))
         assert prompts == [""]
+
+    def test_empty_prompt_stays_in_position(self):
+        # An all-null row in the middle must keep its slot so the list stays
+        # aligned row-for-row with the DataFrame.
+        df = pd.DataFrame({"x": ["hello", None, "world"]})
+        prompts = _build_prompts(df, self.make_vector(["x"]))
+        assert prompts == ["x : hello", "", "x : world"]
 
     def test_no_double_spaces_with_middle_null(self):
         df = pd.DataFrame({"a": ["v1"], "b": [None], "c": ["v3"]})
@@ -233,3 +242,41 @@ class TestEmbedDataframe:
         # The empty prompt was never passed to the encoder.
         (called_prompts,), _ = mock_encoder.encode.call_args
         assert called_prompts == ["name : Alice", "name : Charlie"]
+
+    def test_each_item_keeps_its_own_embedding(self):
+        # The embedding an item ends up with must be the one built from *that*
+        # item's prompt, even when a middle item is dropped and the input has a
+        # non-default index.
+        def encode_from_prompts(prompts, **kwargs):
+            # Turn each prompt into a distinct, content-derived vector so any
+            # mismatch between items and embeddings would show up.
+            return np.array([[float(len(p)), float(ord(p[-1]))] for p in prompts])
+
+        mock_encoder = MagicMock()
+        mock_encoder.device = "cpu"
+        mock_encoder.encode.side_effect = encode_from_prompts
+
+        df = pd.DataFrame(
+            {
+                "item_id": ["a", "b", "c", "d"],
+                "content_hash": ["h1", "h2", "h3", "h4"],
+                "name": ["Alice", "Bob", None, "Dana"],
+            },
+            index=[10, 20, 30, 40],  # non-default index must not break alignment
+        )
+        vectors = [Vector(name="emb", features=["name"], encoder_name="test/model")]
+        encoders = {"test/model": mock_encoder}
+
+        result = embed_dataframe(df, vectors, encoders)
+
+        # "c" is dropped; the survivors keep their order and identity.
+        assert result["item_id"].tolist() == ["a", "b", "d"]
+
+        # Each surviving item maps to the embedding built from its own prompt.
+        expected = {
+            "a": [float(len("name : Alice")), float(ord("e"))],
+            "b": [float(len("name : Bob")), float(ord("b"))],
+            "d": [float(len("name : Dana")), float(ord("a"))],
+        }
+        for item_id, embedding in zip(result["item_id"], result["emb"]):
+            assert embedding == expected[item_id]

--- a/jobs/ml_jobs/item_embedding/tests/test_embedding.py
+++ b/jobs/ml_jobs/item_embedding/tests/test_embedding.py
@@ -182,3 +182,29 @@ class TestEmbedDataframe:
 
         # Verify encoder.encode was called
         assert mock_encoder.encode.called
+
+    def test_all_null_row_gets_none_and_is_not_embedded(self):
+        # Only the two non-empty rows should be embedded; the all-null row
+        # must not be sent to the encoder and must get None in the output.
+        mock_encoder = MagicMock()
+        mock_encoder.device = "cpu"
+        mock_encoder.encode.return_value = np.array([[1.0, 2.0], [5.0, 6.0]])
+
+        df = pd.DataFrame(
+            {
+                "item_id": ["a", "b", "c"],
+                "content_hash": ["h1", "h2", "h3"],
+                "name": ["Alice", None, "Charlie"],
+            }
+        )
+        vectors = [Vector(name="emb", features=["name"], encoder_name="test/model")]
+        encoders = {"test/model": mock_encoder}
+
+        result = embed_dataframe(df, vectors, encoders)
+
+        # Middle (all-null) row is None; the others keep their embeddings.
+        assert result["emb"].tolist() == [[1.0, 2.0], None, [5.0, 6.0]]
+
+        # The empty prompt was never passed to the encoder.
+        (called_prompts,), _ = mock_encoder.encode.call_args
+        assert called_prompts == ["name : Alice", "name : Charlie"]

--- a/jobs/ml_jobs/item_embedding/tests/test_embedding.py
+++ b/jobs/ml_jobs/item_embedding/tests/test_embedding.py
@@ -205,9 +205,10 @@ class TestEmbedDataframe:
         # Verify encoder.encode was called
         assert mock_encoder.encode.called
 
-    def test_all_null_row_gets_none_and_is_not_embedded(self):
+    def test_all_null_row_is_skipped_and_not_embedded(self):
         # Only the two non-empty rows should be embedded; the all-null row
-        # must not be sent to the encoder and must get None in the output.
+        # must not be sent to the encoder and must be dropped from the output,
+        # so no null vector ever reaches the parquet.
         mock_encoder = MagicMock()
         mock_encoder.device = "cpu"
         mock_encoder.encode.return_value = np.array([[1.0, 2.0], [5.0, 6.0]])
@@ -224,8 +225,10 @@ class TestEmbedDataframe:
 
         result = embed_dataframe(df, vectors, encoders)
 
-        # Middle (all-null) row is None; the others keep their embeddings.
-        assert result["emb"].tolist() == [[1.0, 2.0], None, [5.0, 6.0]]
+        # The all-null item ("b") is excluded; survivors keep their embeddings.
+        assert result["item_id"].tolist() == ["a", "c"]
+        assert result["emb"].tolist() == [[1.0, 2.0], [5.0, 6.0]]
+        assert result["emb"].notna().all()
 
         # The empty prompt was never passed to the encoder.
         (called_prompts,), _ = mock_encoder.encode.call_args


### PR DESCRIPTION
## Changes
**1. prompt name change from query to document.**
 The previous query prompt applied the search-query instruction to full item text. document is the correct corpus-side prompt and works for item↔item similarity, clustering, and as a feature. Note that to use these embeddings in retrieval, you should embed the query with the "query"prompt name from embedding gemma
 
**2. L2-normalize embeddings**
 normalize_embeddings=True
 
**3. None for all-null items.** 
Rows with no usable metadata are no longer embedded — previously they collapsed to one identical "bare instruction" vector and looked like mutual near-duplicates. They now get None (read back as an empty array in BigQuery) and skip the model entirely.

**4. Optional feature labels.** 
Optional labels map each feature name to a clear French label in the prompt (offer_name becomes titre de l'offre, author_concat -> auteur/artiste, …) Column names are unchanged — labels affect prompt text only.