### PR TITLE
(DE-4292) fix(event series): Fix event series transfo

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series.sql
@@ -8,25 +8,63 @@ with
             cast(comment as string) as comment,
             cast(event_name as string) as event_name
         from {{ source("ml_preproc", "delta_event_series") }}
+    ),
+
+    added_delta_event_series as (
+        select
+            event_series_id,
+            event_series_description,
+            event_series_image_url,
+            action,
+            comment,
+            event_name as event_series_name,
+            regexp_extract(
+                event_series_image_url, r'/mediations/([^/]+)'
+            ) as event_series_mediation_uuid
+        from casted_delta_event_series
+        where action = 'add'
+    ),
+
+    removed_or_updated_delta_event_series as (
+        select
+            casted_delta_event_series.event_series_id,
+            casted_delta_event_series.event_series_description,
+            casted_delta_event_series.event_series_image_url,
+            casted_delta_event_series.action,
+            casted_delta_event_series.comment,
+            case
+                when casted_delta_event_series.action = 'remove'
+                then applicative_database_event_series.event_series_name
+                else casted_delta_event_series.event_name
+            end as event_series_name,
+            regexp_extract(
+                casted_delta_event_series.event_series_image_url, r'/mediations/([^/]+)'
+            ) as event_series_mediation_uuid
+        from casted_delta_event_series
+        inner join
+            {{ source("raw", "applicative_database_event_series") }}
+            as applicative_database_event_series
+            on casted_delta_event_series.event_series_id
+            = applicative_database_event_series.event_series_id
+        where casted_delta_event_series.action in ('update', 'remove')
     )
 
 select
-    casted_delta_event_series.event_series_id,
-    casted_delta_event_series.event_series_description,
-    casted_delta_event_series.event_series_image_url,
-    casted_delta_event_series.action,
-    casted_delta_event_series.comment,
-    case
-        when casted_delta_event_series.action = 'remove'
-        then applicative_database_event_series.event_series_name
-        else casted_delta_event_series.event_name
-    end as event_series_name,
-    regexp_extract(
-        casted_delta_event_series.event_series_image_url, r'/mediations/([^/]+)'
-    ) as event_series_mediation_uuid
-from casted_delta_event_series
-left join
-    {{ source("raw", "applicative_database_event_series") }}
-    as applicative_database_event_series
-    on casted_delta_event_series.event_series_id
-    = applicative_database_event_series.event_series_id
+    added_delta_event_series.event_series_id,
+    added_delta_event_series.event_series_description,
+    added_delta_event_series.event_series_image_url,
+    added_delta_event_series.action,
+    added_delta_event_series.comment,
+    added_delta_event_series.event_series_name,
+    added_delta_event_series.event_series_mediation_uuid
+from added_delta_event_series
+union all
+select
+    removed_or_updated_delta_event_series.event_series_id,
+    removed_or_updated_delta_event_series.event_series_description,
+    removed_or_updated_delta_event_series.event_series_image_url,
+    removed_or_updated_delta_event_series.action,
+    removed_or_updated_delta_event_series.comment,
+    removed_or_updated_delta_event_series.event_series_name,
+    removed_or_updated_delta_event_series.event_series_mediation_uuid
+from removed_or_updated_delta_event_series

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series_offer_link.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series_offer_link.sql
@@ -1,6 +1,38 @@
-select
-    cast(event_id as string) as event_series_id,
-    cast(offer_id as string) as offer_id,
-    cast(action as string) as action,  -- noqa: disable=RF04
-    cast(comment as string) as comment
-from {{ source("ml_preproc", "delta_event_series_offer_link") }}
+with
+    casted_delta_event_series_offer_link as (
+        select
+            cast(event_id as string) as event_series_id,
+            cast(offer_id as string) as offer_id,
+            cast(action as string) as action,  -- noqa: disable=RF04
+            cast(comment as string) as comment
+        from {{ source("ml_preproc", "delta_event_series_offer_link") }}
+    ),
+
+    added_delta_event_series_offer_link as (
+        select event_series_id, offer_id, action, comment
+        from casted_delta_event_series_offer_link
+        where action = 'add'
+    ),
+
+    removed_or_updated_delta_event_series_offer_link as (
+        select
+            casted_delta_event_series_offer_link.event_series_id,
+            casted_delta_event_series_offer_link.offer_id,
+            casted_delta_event_series_offer_link.action,
+            casted_delta_event_series_offer_link.comment
+        from casted_delta_event_series_offer_link
+        inner join
+            {{ source("raw", "applicative_database_event_series_offer_link") }}
+            as applicative_database_event_series_offer_link
+            on casted_delta_event_series_offer_link.event_series_id
+            = applicative_database_event_series_offer_link.event_series_id
+            and casted_delta_event_series_offer_link.offer_id
+            = cast(applicative_database_event_series_offer_link.offer_id as string)
+        where casted_delta_event_series_offer_link.action in ('update', 'remove')
+    )
+
+select *
+from added_delta_event_series_offer_link
+union all
+select *
+from removed_or_updated_delta_event_series_offer_link


### PR DESCRIPTION
# DE PR

## Describe your changes

This PR fixes `ml_linkage__delta_event_series` and `ml_linkage__delta_event_series_offer_link`
so that `remove`/`update` delta rows are dropped when the underlying id (or link) doesn't
actually exist in the corresponding `applicative_database_*` table, instead of silently
passing through with a null name / a phantom link. Only `add` rows stay exempt from this
check, since a brand-new record legitimately doesn't exist there yet.

Motivation: `event_series_name` carries a **critical** `not_null` test, and
`ml_linkage__delta_event_series` feeds `exp_backend__event_series_delta` directly — an
orphaned `remove`/`update` delta (referencing an id/link that was never actually created)
was either failing that test or exporting a null-name row straight to the backend sync.

### 🔧 Changements

- `ml_linkage__delta_event_series.sql`: split into `added_delta_event_series`
  (`action = 'add'`, passthrough) and `removed_or_updated_delta_event_series`
  (`action in ('update', 'remove')`, now `INNER JOIN`ed on `event_series_id` against
  `applicative_database_event_series` — no match, no row), unioned together.
- `ml_linkage__delta_event_series_offer_link.sql`: same split, joined on
  `(event_series_id, offer_id)` against `applicative_database_event_series_offer_link`.
  Mirrors the "must exist" semantics already used downstream in
  `ml_linkage__future_event_series_offer_link.sql`, where `update` is treated as an
  upsert (remove-if-exists + add).

## Jira ticket number and/or notion link

None (BSR)

### Type of change

- [x] Fix (non-breaking change which corrects expected behavior)

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] I have updated the dag
- [ ] If my changes concern incremental table, I have altered their schema to accomodate with field's creation/deletion
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket

Existing `not_null`/`accepted_values` schema tests on both models already cover the
guarantees this fix restores; no new test cases needed.

### 🧪 Comment tester

- `dbt test --select ml_linkage__delta_event_series ml_linkage__delta_event_series_offer_link`
- Sanity-check with a sample: a `remove`/`update` row whose id (or link) is absent from
  the applicative table should now be dropped; an `add` row with no matching applicative
  record should still appear.

---
**🧭 Review effort : 2/5** — petit diff, logique localisée (CTE split + inner join), déjà
précédée par le même pattern dans `ml_linkage__future_event_series_offer_link.sql`.

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `ml_linkage__delta_event_series.sql` | Split add vs remove/update, inner join requis pour remove/update |
| `ml_linkage__delta_event_series_offer_link.sql` | Même split, join sur `(event_series_id, offer_id)` |