### PR TITLE
(DE-3632) feat(artist): Add future artist tables

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__future_artist.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__future_artist.md
@@ -1,0 +1,18 @@
+---
+title: Future Artist
+description: Description of the `ml_linkage__future_artist` table.
+---
+
+{% docs description__ml_linkage__future_artist %}
+
+# Table: Future Artist
+
+The `ml_linkage__future_artist` table contains a preview of the artists once ingestion of the delta artist is completed.
+
+This table is used to validate that the future state of the artists is correct before synchronizing with the backend application by running dbt tests on it.
+
+{% enddocs %}
+
+## Table description
+
+{% docs table__ml_linkage__future_artist %}{% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__future_product_artist_link.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__future_product_artist_link.md
@@ -1,0 +1,18 @@
+---
+title: Future Product Artist Link
+description: Description of the `ml_linkage__future_product_artist_link` table.
+---
+
+{% docs description__ml_linkage__future_product_artist_link %}
+
+# Table: Future Product Artist Link
+
+The `ml_linkage__future_product_artist_link` table contains a preview of the product/artist link once ingestion of the delta product artist link and delta artist is completed.
+
+This table is used to validate that the future state of the artists and product artist links are correct before synchronizing with the backend application by running dbt tests on it.
+
+{% enddocs %}
+
+## Table description
+
+{% docs table__ml_linkage__future_product_artist_link %}{% enddocs %}

--- a/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__artist_delta.sql
+++ b/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__artist_delta.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('ml_linkage__future_artist') }}
+-- depends_on: {{ ref('ml_linkage__future_product_artist_link') }}
 select
     artist_id,
     artist_name,

--- a/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__product_artist_link_delta.sql
+++ b/orchestration/dags/data_gcp_dbt/models/export/backend/data_science/exp_backend__product_artist_link_delta.sql
@@ -1,2 +1,4 @@
+-- depends_on: {{ ref('ml_linkage__future_artist') }}
+-- depends_on: {{ ref('ml_linkage__future_product_artist_link') }}
 select offer_product_id, artist_id, artist_type, action, comment
 from {{ ref("ml_linkage__delta_product_artist_link") }}

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_artist.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_artist.yml
@@ -8,7 +8,6 @@ models:
         description: "{{ doc('column__artist_id') }}"
         data_tests:
           - not_null
-          - unique
           - dbt_utils.not_empty_string
       - name: artist_name
         description: "{{ doc('column__artist_name') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_artist.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_artist.yml
@@ -7,18 +7,14 @@ models:
       - name: artist_id
         description: "{{ doc('column__artist_id') }}"
         data_tests:
-          - not_null:
-              config:
-                tags: ['critical']
-          - unique:
-              config:
-                tags: ['critical']
+          - not_null
+          - unique
+          - dbt_utils.not_empty_string
       - name: artist_name
         description: "{{ doc('column__artist_name') }}"
         data_tests:
-          - not_null:
-              config:
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: artist_description
         description: "{{ doc('column__artist_description') }}"
       - name: artist_biography
@@ -39,5 +35,9 @@ models:
         description: "{{ doc('column__wikidata_image_license_url') }}"
       - name: action
         description: "{{ doc('column__delta_action') }}"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['add', 'update', 'remove']
       - name: comment
         description: "{{ doc('column__delta_comment') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_event_series.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_event_series.yml
@@ -7,25 +7,13 @@ models:
       - name: event_series_id
         description: "{{ doc('column__event_series_id') }}"
         data_tests:
-          - not_null:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
-          - dbt_utils.not_empty_string:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: event_series_name
         description: "{{ doc('column__event_series_name') }}"
         data_tests:
-          - not_null:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
-          - dbt_utils.not_empty_string:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: event_series_description
         description: "{{ doc('column__event_series_description') }}"
       - name: event_series_image_url
@@ -38,8 +26,5 @@ models:
           - accepted_values:
               arguments:
                 values: ['add', 'update', 'remove']
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
       - name: comment
         description: "{{ doc('column__delta_comment') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_event_series_offer_link.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_event_series_offer_link.yml
@@ -7,33 +7,18 @@ models:
       - name: event_series_id
         description: "{{ doc('column__event_series_id') }}"
         data_tests:
-          - not_null:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
-          - dbt_utils.not_empty_string:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: offer_id
         description: "{{ doc('column__offer_id') }}"
         data_tests:
-          - not_null:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
-          - dbt_utils.not_empty_string:
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: action
         description: "{{ doc('column__delta_action') }}"
         data_tests:
           - accepted_values:
               arguments:
                 values: ['add', 'update', 'remove']
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
       - name: comment
         description: "{{ doc('column__delta_comment') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_product_artist_link.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_product_artist_link.yml
@@ -7,22 +7,25 @@ models:
       - name: offer_product_id
         description: "{{ doc('column__offer_product_id') }}"
         data_tests:
-          - not_null:
-              config:
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: artist_id
         description: "{{ doc('column__artist_id') }}"
         data_tests:
-          - not_null:
-              config:
-                tags: ['critical']
+          - not_null
+          - dbt_utils.not_empty_string
       - name: artist_type
         description: "{{ doc('column__artist_type') }}"
         data_tests:
-          - not_null:
-              config:
-                tags: ['critical']
+          - not_null
       - name: action
         description: "{{ doc('column__delta_action') }}"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['add', 'update', 'remove']
+              config:
+                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
+                tags: ['critical']
       - name: comment
         description: "{{ doc('column__delta_comment') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_product_artist_link.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__delta_product_artist_link.yml
@@ -24,8 +24,5 @@ models:
           - accepted_values:
               arguments:
                 values: ['add', 'update', 'remove']
-              config:
-                severity: "{{ var('test_severity', {}).get(target.name, 'error') }}"
-                tags: ['critical']
       - name: comment
         description: "{{ doc('column__delta_comment') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_artist.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_artist.yml
@@ -10,13 +10,11 @@ models:
           - not_null
           - dbt_utils.not_empty_string
           - unique
-
       - name: artist_name
         description: "{{ doc('column__artist_name') }}"
         data_tests:
           - not_null
           - dbt_utils.not_empty_string
-
       - name: artist_description
         description: "{{ doc('column__artist_description') }}"
       - name: artist_biography
@@ -25,6 +23,8 @@ models:
         description: "{{ doc('column__artist_mediation_uuid') }}"
       - name: wikidata_id
         description: "{{ doc('column__artist_wiki_id') }}"
+        data_tests:
+          - unique
       - name: wikipedia_url
         description: "{{ doc('column__artist_wikipedia_url') }}"
       - name: wikidata_image_file_url

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_artist.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_artist.yml
@@ -1,0 +1,37 @@
+version: 2
+
+models:
+  - name: ml_linkage__future_artist
+    description: "{{ doc('description__ml_linkage__future_artist') }}"
+    columns:
+      - name: artist_id
+        description: "{{ doc('column__artist_id') }}"
+        data_tests:
+          - not_null
+          - dbt_utils.not_empty_string
+          - unique
+
+      - name: artist_name
+        description: "{{ doc('column__artist_name') }}"
+        data_tests:
+          - not_null
+          - dbt_utils.not_empty_string
+
+      - name: artist_description
+        description: "{{ doc('column__artist_description') }}"
+      - name: artist_biography
+        description: "{{ doc('column__artist_biography') }}"
+      - name: artist_mediation_uuid
+        description: "{{ doc('column__artist_mediation_uuid') }}"
+      - name: wikidata_id
+        description: "{{ doc('column__artist_wiki_id') }}"
+      - name: wikipedia_url
+        description: "{{ doc('column__artist_wikipedia_url') }}"
+      - name: wikidata_image_file_url
+        description: "{{ doc('column__wikidata_image_file_url') }}"
+      - name: wikidata_image_author
+        description: "{{ doc('column__wikidata_image_author') }}"
+      - name: wikidata_image_license
+        description: "{{ doc('column__wikidata_image_license') }}"
+      - name: wikidata_image_license_url
+        description: "{{ doc('column__wikidata_image_license_url') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_event_series_offer_link.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_event_series_offer_link.yml
@@ -10,8 +10,9 @@ models:
           - not_null
           - dbt_utils.not_empty_string
           - relationships:
-              to: ref('ml_linkage__future_event_series')
-              field: event_series_id
+              arguments:
+                to: ref('ml_linkage__future_event_series')
+                field: event_series_id
 
       - name: offer_id
         description: "{{ doc('column__offer_id') }}"

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_product_artist_link.yml
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/_schema/ml_linkage__future_product_artist_link.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+  - name: ml_linkage__future_product_artist_link
+    description: "{{ doc('description__ml_linkage__future_product_artist_link') }}"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - offer_product_id
+              - artist_id
+              - artist_type
+    columns:
+      - name: offer_product_id
+        description: "{{ doc('column__offer_product_id') }}"
+        data_tests:
+          - not_null
+          - dbt_utils.not_empty_string
+
+      - name: artist_id
+        description: "{{ doc('column__artist_id') }}"
+        data_tests:
+          - not_null
+          - dbt_utils.not_empty_string
+          - relationships:
+              arguments:
+                to: ref('ml_linkage__future_artist')
+                field: artist_id
+
+      - name: artist_type
+        description: "{{ doc('column__artist_type') }}"
+        data_tests:
+          - not_null

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_artist.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_artist.sql
@@ -1,6 +1,82 @@
-{{ config(**custom_table_config(materialized="view")) }}
-
 with
+    casted_delta_artist as (
+        select
+            cast(artist_id as string) as artist_id,
+            cast(artist_name as string) as artist_name,
+            cast(artist_description as string) as artist_description,
+            cast(artist_biography as string) as artist_biography,
+            cast(artist_mediation_uuid as string) as artist_mediation_uuid,
+            cast(wikidata_id as string) as wikidata_id,
+            cast(wikipedia_url as string) as wikipedia_url,
+            cast(wikidata_image_file_url as string) as wikidata_image_file_url,
+            cast(wikidata_image_author as string) as wikidata_image_author,
+            cast(wikidata_image_license as string) as wikidata_image_license,
+            cast(wikidata_image_license_url as string) as wikidata_image_license_url,
+            cast(spotify_id as string) as spotify_id,
+            cast(isni_id as string) as isni_id,
+            cast(apple_music_id as string) as apple_music_id,
+            cast(deezer_id as string) as deezer_id,
+            cast(genius_id as string) as genius_id,
+            cast(soundcloud_id as string) as soundcloud_id,
+            cast(action as string) as action,  -- noqa: disable=RF04
+            cast(comment as string) as comment
+        from {{ source("ml_preproc", "delta_artist") }}
+    ),
+
+    added_delta_artist as (
+        select
+            artist_id,
+            artist_name,
+            artist_description,
+            artist_biography,
+            artist_mediation_uuid,
+            wikidata_id,
+            wikipedia_url,
+            wikidata_image_file_url,
+            wikidata_image_author,
+            wikidata_image_license,
+            wikidata_image_license_url,
+            spotify_id,
+            isni_id,
+            apple_music_id,
+            deezer_id,
+            genius_id,
+            soundcloud_id,
+            action,
+            comment
+        from casted_delta_artist
+        where action = 'add'
+    ),
+
+    removed_or_updated_delta_artist as (
+        select
+            casted_delta_artist.artist_id,
+            casted_delta_artist.artist_name,
+            casted_delta_artist.artist_description,
+            casted_delta_artist.artist_biography,
+            casted_delta_artist.artist_mediation_uuid,
+            casted_delta_artist.wikidata_id,
+            casted_delta_artist.wikipedia_url,
+            casted_delta_artist.wikidata_image_file_url,
+            casted_delta_artist.wikidata_image_author,
+            casted_delta_artist.wikidata_image_license,
+            casted_delta_artist.wikidata_image_license_url,
+            casted_delta_artist.spotify_id,
+            casted_delta_artist.isni_id,
+            casted_delta_artist.apple_music_id,
+            casted_delta_artist.deezer_id,
+            casted_delta_artist.genius_id,
+            casted_delta_artist.soundcloud_id,
+            casted_delta_artist.action,
+            casted_delta_artist.comment
+        from casted_delta_artist
+        inner join
+            {{ source("raw", "applicative_database_artist") }}
+            as applicative_database_artist
+            on casted_delta_artist.artist_id = applicative_database_artist.artist_id
+        where casted_delta_artist.action in ('update', 'remove')
+    ),
+
     artist_linked as (
         select distinct artist_id, true as is_linked
         from {{ ref("int_applicative__product_artist_link") }}
@@ -16,63 +92,92 @@ with
             artist.wikidata_id,
             artist.wikipedia_url,
             artist.wikidata_image_file_url,
+            artist.wikidata_image_author,
             artist.wikidata_image_license,
             artist.wikidata_image_license_url,
-            artist.wikidata_image_author,
             cast(null as string) as spotify_id,
             cast(null as string) as isni_id,
             cast(null as string) as apple_music_id,
             cast(null as string) as deezer_id,
             cast(null as string) as genius_id,
             cast(null as string) as soundcloud_id,
-            'remove' as action,  -- noqa: RF04
-            'artist not linked to any product' as comment  -- noqa: RF04
+            'remove' as action,
+            'artist not linked to any product' as comment
         from {{ ref("int_applicative__artist") }} as artist
         left join artist_linked using (artist_id)
-        where (artist_linked.is_linked is null) and (artist.wikidata_id is null)
-        order by artist.artist_name
+        where
+            artist_linked.is_linked is null
+            and artist.wikidata_id is null
+            -- an artist already carried by the delta must not be emitted twice
+            and not exists (
+                select 1 as found
+                from casted_delta_artist as delta
+                where delta.artist_id = artist.artist_id
+            )
     )
 
 select
-    cast(artist_id as string) as artist_id,
-    cast(artist_name as string) as artist_name,
-    cast(artist_description as string) as artist_description,
-    cast(artist_biography as string) as artist_biography,
-    cast(artist_mediation_uuid as string) as artist_mediation_uuid,
-    cast(wikidata_id as string) as wikidata_id,
-    cast(wikipedia_url as string) as wikipedia_url,
-    cast(wikidata_image_file_url as string) as wikidata_image_file_url,
-    cast(wikidata_image_author as string) as wikidata_image_author,
-    cast(wikidata_image_license as string) as wikidata_image_license,
-    cast(wikidata_image_license_url as string) as wikidata_image_license_url,
-    cast(spotify_id as string) as spotify_id,
-    cast(isni_id as string) as isni_id,
-    cast(apple_music_id as string) as apple_music_id,
-    cast(deezer_id as string) as deezer_id,
-    cast(genius_id as string) as genius_id,
-    cast(soundcloud_id as string) as soundcloud_id,
-    cast(action as string) as action,  -- noqa: RF04
-    cast(comment as string) as comment  -- noqa: RF04
-from {{ source("ml_preproc", "delta_artist") }}
+    added_delta_artist.artist_id,
+    added_delta_artist.artist_name,
+    added_delta_artist.artist_description,
+    added_delta_artist.artist_biography,
+    added_delta_artist.artist_mediation_uuid,
+    added_delta_artist.wikidata_id,
+    added_delta_artist.wikipedia_url,
+    added_delta_artist.wikidata_image_file_url,
+    added_delta_artist.wikidata_image_author,
+    added_delta_artist.wikidata_image_license,
+    added_delta_artist.wikidata_image_license_url,
+    added_delta_artist.spotify_id,
+    added_delta_artist.isni_id,
+    added_delta_artist.apple_music_id,
+    added_delta_artist.deezer_id,
+    added_delta_artist.genius_id,
+    added_delta_artist.soundcloud_id,
+    added_delta_artist.action,
+    added_delta_artist.comment
+from added_delta_artist
 union all
 select
-    artist_id,
-    artist_name,
-    artist_description,
-    artist_biography,
-    artist_mediation_uuid,
-    wikidata_id,
-    wikipedia_url,
-    wikidata_image_file_url,
-    wikidata_image_author,
-    wikidata_image_license,
-    wikidata_image_license_url,
-    spotify_id,
-    isni_id,
-    apple_music_id,
-    deezer_id,
-    genius_id,
-    soundcloud_id,
-    action,
-    comment
+    removed_or_updated_delta_artist.artist_id,
+    removed_or_updated_delta_artist.artist_name,
+    removed_or_updated_delta_artist.artist_description,
+    removed_or_updated_delta_artist.artist_biography,
+    removed_or_updated_delta_artist.artist_mediation_uuid,
+    removed_or_updated_delta_artist.wikidata_id,
+    removed_or_updated_delta_artist.wikipedia_url,
+    removed_or_updated_delta_artist.wikidata_image_file_url,
+    removed_or_updated_delta_artist.wikidata_image_author,
+    removed_or_updated_delta_artist.wikidata_image_license,
+    removed_or_updated_delta_artist.wikidata_image_license_url,
+    removed_or_updated_delta_artist.spotify_id,
+    removed_or_updated_delta_artist.isni_id,
+    removed_or_updated_delta_artist.apple_music_id,
+    removed_or_updated_delta_artist.deezer_id,
+    removed_or_updated_delta_artist.genius_id,
+    removed_or_updated_delta_artist.soundcloud_id,
+    removed_or_updated_delta_artist.action,
+    removed_or_updated_delta_artist.comment
+from removed_or_updated_delta_artist
+union all
+select
+    artists_to_remove.artist_id,
+    artists_to_remove.artist_name,
+    artists_to_remove.artist_description,
+    artists_to_remove.artist_biography,
+    artists_to_remove.artist_mediation_uuid,
+    artists_to_remove.wikidata_id,
+    artists_to_remove.wikipedia_url,
+    artists_to_remove.wikidata_image_file_url,
+    artists_to_remove.wikidata_image_author,
+    artists_to_remove.wikidata_image_license,
+    artists_to_remove.wikidata_image_license_url,
+    artists_to_remove.spotify_id,
+    artists_to_remove.isni_id,
+    artists_to_remove.apple_music_id,
+    artists_to_remove.deezer_id,
+    artists_to_remove.genius_id,
+    artists_to_remove.soundcloud_id,
+    artists_to_remove.action,
+    artists_to_remove.comment
 from artists_to_remove

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_artist.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_artist.sql
@@ -23,66 +23,13 @@ with
         from {{ source("ml_preproc", "delta_artist") }}
     ),
 
-    added_delta_artist as (
-        select
-            artist_id,
-            artist_name,
-            artist_description,
-            artist_biography,
-            artist_mediation_uuid,
-            wikidata_id,
-            wikipedia_url,
-            wikidata_image_file_url,
-            wikidata_image_author,
-            wikidata_image_license,
-            wikidata_image_license_url,
-            spotify_id,
-            isni_id,
-            apple_music_id,
-            deezer_id,
-            genius_id,
-            soundcloud_id,
-            action,
-            comment
-        from casted_delta_artist
-        where action = 'add'
-    ),
-
-    removed_or_updated_delta_artist as (
-        select
-            casted_delta_artist.artist_id,
-            casted_delta_artist.artist_name,
-            casted_delta_artist.artist_description,
-            casted_delta_artist.artist_biography,
-            casted_delta_artist.artist_mediation_uuid,
-            casted_delta_artist.wikidata_id,
-            casted_delta_artist.wikipedia_url,
-            casted_delta_artist.wikidata_image_file_url,
-            casted_delta_artist.wikidata_image_author,
-            casted_delta_artist.wikidata_image_license,
-            casted_delta_artist.wikidata_image_license_url,
-            casted_delta_artist.spotify_id,
-            casted_delta_artist.isni_id,
-            casted_delta_artist.apple_music_id,
-            casted_delta_artist.deezer_id,
-            casted_delta_artist.genius_id,
-            casted_delta_artist.soundcloud_id,
-            casted_delta_artist.action,
-            casted_delta_artist.comment
-        from casted_delta_artist
-        inner join
-            {{ source("raw", "applicative_database_artist") }}
-            as applicative_database_artist
-            on casted_delta_artist.artist_id = applicative_database_artist.artist_id
-        where casted_delta_artist.action in ('update', 'remove')
-    ),
-
     artist_linked as (
         select distinct artist_id, true as is_linked
         from {{ ref("int_applicative__product_artist_link") }}
     ),
 
-    artists_to_remove as (
+    -- remove artist with no product link and no wikidata id
+    orphan_artist_to_remove as (
         select
             artist.artist_id,
             artist.artist_name,
@@ -114,70 +61,62 @@ with
                 from casted_delta_artist as delta
                 where delta.artist_id = artist.artist_id
             )
+    ),
+
+    delta_artist as (
+        select *
+        from casted_delta_artist
+        union all
+        select *
+        from orphan_artist_to_remove
+    ),
+
+    added_delta_artist as (select * from delta_artist where action = 'add'),
+
+    removed_or_updated_delta_artist as (
+        select
+            delta_artist.* replace (
+                -- on a remove the delta may not carry the name, take it from
+                -- applicative
+                case
+                    when delta_artist.action = 'remove'
+                    then artist.artist_name
+                    else delta_artist.artist_name
+                end as artist_name
+            )
+        from delta_artist
+        inner join
+            {{ ref("int_applicative__artist") }} as artist
+            on delta_artist.artist_id = artist.artist_id
+        where delta_artist.action in ('update', 'remove')
+    ),
+
+    final_delta_artist as (
+        select *
+        from added_delta_artist
+        union all
+        select *
+        from removed_or_updated_delta_artist
     )
 
 select
-    added_delta_artist.artist_id,
-    added_delta_artist.artist_name,
-    added_delta_artist.artist_description,
-    added_delta_artist.artist_biography,
-    added_delta_artist.artist_mediation_uuid,
-    added_delta_artist.wikidata_id,
-    added_delta_artist.wikipedia_url,
-    added_delta_artist.wikidata_image_file_url,
-    added_delta_artist.wikidata_image_author,
-    added_delta_artist.wikidata_image_license,
-    added_delta_artist.wikidata_image_license_url,
-    added_delta_artist.spotify_id,
-    added_delta_artist.isni_id,
-    added_delta_artist.apple_music_id,
-    added_delta_artist.deezer_id,
-    added_delta_artist.genius_id,
-    added_delta_artist.soundcloud_id,
-    added_delta_artist.action,
-    added_delta_artist.comment
-from added_delta_artist
-union all
-select
-    removed_or_updated_delta_artist.artist_id,
-    removed_or_updated_delta_artist.artist_name,
-    removed_or_updated_delta_artist.artist_description,
-    removed_or_updated_delta_artist.artist_biography,
-    removed_or_updated_delta_artist.artist_mediation_uuid,
-    removed_or_updated_delta_artist.wikidata_id,
-    removed_or_updated_delta_artist.wikipedia_url,
-    removed_or_updated_delta_artist.wikidata_image_file_url,
-    removed_or_updated_delta_artist.wikidata_image_author,
-    removed_or_updated_delta_artist.wikidata_image_license,
-    removed_or_updated_delta_artist.wikidata_image_license_url,
-    removed_or_updated_delta_artist.spotify_id,
-    removed_or_updated_delta_artist.isni_id,
-    removed_or_updated_delta_artist.apple_music_id,
-    removed_or_updated_delta_artist.deezer_id,
-    removed_or_updated_delta_artist.genius_id,
-    removed_or_updated_delta_artist.soundcloud_id,
-    removed_or_updated_delta_artist.action,
-    removed_or_updated_delta_artist.comment
-from removed_or_updated_delta_artist
-union all
-select
-    artists_to_remove.artist_id,
-    artists_to_remove.artist_name,
-    artists_to_remove.artist_description,
-    artists_to_remove.artist_biography,
-    artists_to_remove.artist_mediation_uuid,
-    artists_to_remove.wikidata_id,
-    artists_to_remove.wikipedia_url,
-    artists_to_remove.wikidata_image_file_url,
-    artists_to_remove.wikidata_image_author,
-    artists_to_remove.wikidata_image_license,
-    artists_to_remove.wikidata_image_license_url,
-    artists_to_remove.spotify_id,
-    artists_to_remove.isni_id,
-    artists_to_remove.apple_music_id,
-    artists_to_remove.deezer_id,
-    artists_to_remove.genius_id,
-    artists_to_remove.soundcloud_id,
-    artists_to_remove.action,
-    artists_to_remove.comment
-from artists_to_remove
+    artist_id,
+    artist_name,
+    artist_description,
+    artist_biography,
+    artist_mediation_uuid,
+    wikidata_id,
+    wikipedia_url,
+    wikidata_image_file_url,
+    wikidata_image_author,
+    wikidata_image_license,
+    wikidata_image_license_url,
+    spotify_id,
+    isni_id,
+    apple_music_id,
+    deezer_id,
+    genius_id,
+    soundcloud_id,
+    action,
+    comment
+from final_delta_artist

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_product_artist_link.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_product_artist_link.sql
@@ -1,4 +1,44 @@
-{{ config(**custom_table_config(materialized="view")) }}
+with
+    casted_delta_product_artist_link as (
+        select distinct
+            cast(offer_product_id as string) as offer_product_id,
+            cast(artist_id as string) as artist_id,
+            cast(artist_type as string) as artist_type,
+            cast(action as string) as action,  -- noqa: disable=RF04
+            cast(comment as string) as comment
+        from {{ source("ml_preproc", "delta_product_artist_link") }}
+    ),
 
-select distinct offer_product_id, artist_id, artist_type, action, comment
-from {{ source("ml_preproc", "delta_product_artist_link") }}
+    added_delta_product_artist_link as (
+        select offer_product_id, artist_id, artist_type, action, comment
+        from casted_delta_product_artist_link
+        where action = 'add'
+    ),
+
+    removed_or_updated_delta_product_artist_link as (
+        -- distinct: the applicative link table is joined on its business key, not on
+        -- its primary key, so it could otherwise duplicate a delta row
+        select distinct
+            casted_delta_product_artist_link.offer_product_id,
+            casted_delta_product_artist_link.artist_id,
+            casted_delta_product_artist_link.artist_type,
+            casted_delta_product_artist_link.action,
+            casted_delta_product_artist_link.comment
+        from casted_delta_product_artist_link
+        inner join
+            {{ source("raw", "applicative_database_product_artist_link") }}
+            as applicative_database_product_artist_link
+            on casted_delta_product_artist_link.offer_product_id
+            = cast(applicative_database_product_artist_link.offer_product_id as string)
+            and casted_delta_product_artist_link.artist_id
+            = applicative_database_product_artist_link.artist_id
+            and casted_delta_product_artist_link.artist_type
+            = applicative_database_product_artist_link.artist_type
+        where casted_delta_product_artist_link.action in ('update', 'remove')
+    )
+
+select *
+from added_delta_product_artist_link
+union all
+select *
+from removed_or_updated_delta_product_artist_link

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__future_artist.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__future_artist.sql
@@ -1,0 +1,71 @@
+with
+
+    artist_delta as (
+        select
+            artist_id,
+            artist_name,
+            artist_description,
+            artist_biography,
+            artist_mediation_uuid,
+            wikidata_id,
+            wikipedia_url,
+            wikidata_image_file_url,
+            wikidata_image_author,
+            wikidata_image_license,
+            wikidata_image_license_url,
+            action
+        from {{ ref("ml_linkage__delta_artist") }}
+    ),
+
+    future_artist as (
+        select
+            base.artist_id,
+            base.artist_name,
+            base.artist_description,
+            base.artist_biography,
+            base.artist_mediation_uuid,
+            base.wikidata_id,
+            base.wikipedia_url,
+            base.wikidata_image_file_url,
+            base.wikidata_image_author,
+            base.wikidata_image_license,
+            base.wikidata_image_license_url
+        from {{ ref("int_applicative__artist") }} as base
+        where
+            not exists (
+                select 1 as found
+                from artist_delta as delta
+                where
+                    delta.action in ("remove", "update")
+                    and delta.artist_id = base.artist_id
+            )
+        union all
+        select
+            artist_id,
+            artist_name,
+            artist_description,
+            artist_biography,
+            artist_mediation_uuid,
+            wikidata_id,
+            wikipedia_url,
+            wikidata_image_file_url,
+            wikidata_image_author,
+            wikidata_image_license,
+            wikidata_image_license_url
+        from artist_delta
+        where action in ("add", "update")
+    )
+
+select
+    artist_id,
+    artist_name,
+    artist_description,
+    artist_biography,
+    artist_mediation_uuid,
+    wikidata_id,
+    wikipedia_url,
+    wikidata_image_file_url,
+    wikidata_image_author,
+    wikidata_image_license,
+    wikidata_image_license_url
+from future_artist

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__future_product_artist_link.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__future_product_artist_link.sql
@@ -1,0 +1,30 @@
+-- depends_on: {{ ref('ml_linkage__future_artist') }}
+with
+    product_artist_link_delta as (
+        select offer_product_id, artist_id, artist_type, action
+        from {{ ref("ml_linkage__delta_product_artist_link") }}
+    ),
+
+    future_product_artist_link as (
+        select base.offer_product_id, base.artist_id, base.artist_type
+        from {{ ref("int_applicative__product_artist_link") }} as base
+        where
+            not exists (
+                select 1 as found
+                from product_artist_link_delta as delta
+                where
+                    delta.action in ("remove", "update")
+                    and delta.offer_product_id = base.offer_product_id
+                    and delta.artist_id = base.artist_id
+                    and delta.artist_type = base.artist_type
+            )
+        union all
+        select offer_product_id, artist_id, artist_type
+        from product_artist_link_delta
+        where action in ("add", "update")
+    )
+
+-- distinct: a deduplication `add` can target a link that already exists in the
+-- applicative table, which would otherwise appear twice
+select distinct offer_product_id, artist_id, artist_type
+from future_product_artist_link


### PR DESCRIPTION
## Describe your changes

> Avant de synchroniser un delta d'artistes (ajout/mise à jour/suppression) avec l'application backend, on veut pouvoir **prévisualiser l'état futur** des tables `artist` et `product_artist_link` et faire tourner des tests dbt dessus, afin de détecter un delta invalide *avant* qu'il ne soit appliqué en base applicative.

### 🔧 Changements

#### Nouvelles tables de prévisualisation
- `ml_linkage__future_artist` : projette l'état futur de la table `artist` en appliquant le delta (`add`/`update`/`remove`) sur `int_applicative__artist`.
- `ml_linkage__future_product_artist_link` : idem pour `product_artist_link`, avec un `distinct` final pour absorber un `add` redondant avec un lien déjà existant côté applicatif.
- Ajout des fichiers de doc (`description__ml_linkage__future_artist.md`, `description__ml_linkage__future_product_artist_link.md`) et des schémas `.yml` associés, avec tests `not_null` / `unique` / `dbt_utils.not_empty_string` / `relationships` (le `artist_id` de `future_product_artist_link` doit exister dans `future_artist`).

#### Refonte de `ml_linkage__delta_artist`
- Le modèle ne se contente plus d'ajouter les artistes orphelins (sans lien produit ni wikidata_id) au flux brut du delta : il **fusionne proprement** delta brut + orphelins à supprimer, en excluant les doublons (`not exists` sur `casted_delta_artist`).
- Sur les lignes `update`/`remove`, le `artist_name` est désormais repris depuis la table applicative si le delta ne le porte pas (`replace` sur `remove`).
- Le `materialized="view"` a été retiré (le modèle n'est plus une simple vue passthrough).

#### Refonte de `ml_linkage__delta_product_artist_link`
- Idem : le delta brut est maintenant recoupé avec `raw.applicative_database_product_artist_link` pour les actions `update`/`remove`, avec `distinct` pour éviter la duplication liée à la jointure sur clé métier plutôt que clé primaire.

#### Tests dbt
- Ajout de `accepted_values` sur la colonne `action` (`add`/`update`/`remove`) pour `delta_artist` et `delta_product_artist_link`.
- Simplification des tags `critical` retirés au profit de tests plus stricts (`not_empty_string`, `unique`).
- Fix mineur sur `ml_linkage__future_event_series_offer_link.yml` : la config `relationships` doit être imbriquée sous `arguments` (nouvelle syntaxe dbt-utils).

### 🧪 Comment tester
- `dbt build --select ml_linkage__future_artist ml_linkage__future_product_artist_link ml_linkage__delta_artist ml_linkage__delta_product_artist_link` sur un environnement avec un delta artiste de test (au moins un `add`, un `update`, un `remove`).
- Vérifier que `future_artist`/`future_product_artist_link` ne contiennent pas de doublons et que les artistes marqués `remove` disparaissent bien du futur état.
- Vérifier que les tests `accepted_values`/`relationships`/`unique` passent en CI.

## Jira ticket number and/or notion link

[DE-3632](https://passculture.atlassian.net/browse/DE-3632)

### Type of change

* [ ] Fix (non-breaking change which corrects expected behavior)
* [ ] New fields (non-breaking change)
* [x] New table (non-breaking change)
* [x] Concept change (potentially breaking change which modifies fields according to new or evolving business concepts)
* [ ] Table deletion (potentially breaking change which adds functionality/ table)

### Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] My code passes CI/CD tests
* [ ] I updated README.md
* [ ] I have updated the dag
* [x] If my changes concern incremental table, I have altered their schema to accommodate with field's creation/deletion
* [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?

* [x] 👍 yes

---
**🧭 Review effort : 3/5** — _logique SQL de fusion/dédup non triviale sur 4 modèles, mais bien contenue au pipeline de linkage artiste, avec des tests dbt qui couvrent les invariants clés (unicité, non-duplication, relations)._
