### PR TITLE
(BSR) fix(event_series): Add already_ingested_ CTEs to prevent adding already ingested data

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__delta_event_series.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__delta_event_series.md
@@ -9,6 +9,7 @@ description: Description of the `ml_linkage__delta_event_series` table.
 
 The `ml_linkage__delta_event_series` table contains the new event series data that must be synchronized with the backend application.
 It is an export from the ml_preproc__delta_event_series source computed by the event_linkage DAG.
+`add` rows already present in the applicative database (already ingested by the backend) are excluded, so the table only carries changes still to be applied.
 
 {% enddocs %}
 

--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__delta_event_series_offer_link.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/machine_learning/linkage/description__ml_linkage__delta_event_series_offer_link.md
@@ -9,6 +9,7 @@ description: Description of the `ml_linkage__delta_event_series_offer_link` tabl
 
 The `ml_linkage__delta_event_series_offer_link` table contains the new event series/offer link data that must be synchronized with the backend application.
 It is an export from the ml_preproc__delta_event_series_offer_link source computed by the event_linkage DAG.
+`add` rows already present in the applicative database (already ingested by the backend) are excluded, so the table only carries changes still to be applied.
 
 {% enddocs %}
 

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series.sql
@@ -10,6 +10,24 @@ with
         from {{ source("ml_preproc", "delta_event_series") }}
     ),
 
+    -- applicative event series this delta does not remove: they will still be
+    -- there when the backend ingests, so an "add" on them is a no-op
+    already_ingested_event_series as (
+        select applicative_database_event_series.event_series_id
+        from
+            {{ source("raw", "applicative_database_event_series") }}
+            as applicative_database_event_series
+        where
+            not exists (
+                select 1 as found
+                from casted_delta_event_series as delta
+                where
+                    delta.action in ('remove', 'update')
+                    and delta.event_series_id
+                    = applicative_database_event_series.event_series_id
+            )
+    ),
+
     added_delta_event_series as (
         select
             event_series_id,
@@ -22,7 +40,16 @@ with
                 event_series_image_url, r'/mediations/([^/]+)'
             ) as event_series_mediation_uuid
         from casted_delta_event_series
-        where action = 'add'
+        where
+            action = 'add'
+            -- these models are rebuilt daily while ingestion runs weekly: do not
+            -- re-send an event series already ingested in the applicative database
+            and not exists (
+                select 1 as found
+                from already_ingested_event_series as ingested
+                where
+                    ingested.event_series_id = casted_delta_event_series.event_series_id
+            )
     ),
 
     removed_or_updated_delta_event_series as (

--- a/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series_offer_link.sql
+++ b/orchestration/dags/data_gcp_dbt/models/machine_learning/linkage/ml_linkage__delta_event_series_offer_link.sql
@@ -8,10 +8,47 @@ with
         from {{ source("ml_preproc", "delta_event_series_offer_link") }}
     ),
 
+    -- applicative event series/offer links this delta does not remove: they
+    -- will still be there when the backend ingests, so an "add" is a no-op
+    already_ingested_event_series_offer_link as (
+        select
+            applicative_database_event_series_offer_link.event_series_id,
+            cast(
+                applicative_database_event_series_offer_link.offer_id as string
+            ) as offer_id
+        from
+            {{ source("raw", "applicative_database_event_series_offer_link") }}
+            as applicative_database_event_series_offer_link
+        where
+            not exists (
+                select 1 as found
+                from casted_delta_event_series_offer_link as delta
+                where
+                    delta.action in ('remove', 'update')
+                    and delta.event_series_id
+                    = applicative_database_event_series_offer_link.event_series_id
+                    and delta.offer_id = cast(
+                        applicative_database_event_series_offer_link.offer_id as string
+                    )
+            )
+    ),
+
     added_delta_event_series_offer_link as (
         select event_series_id, offer_id, action, comment
         from casted_delta_event_series_offer_link
-        where action = 'add'
+        where
+            action = 'add'
+            -- these models are rebuilt daily while ingestion runs weekly: do not
+            -- re-send a link already ingested in the applicative database
+            and not exists (
+                select 1 as found
+                from already_ingested_event_series_offer_link as ingested
+                where
+                    ingested.event_series_id
+                    = casted_delta_event_series_offer_link.event_series_id
+                    and ingested.offer_id
+                    = casted_delta_event_series_offer_link.offer_id
+            )
     ),
 
     removed_or_updated_delta_event_series_offer_link as (


### PR DESCRIPTION
# DE PR

## Describe your changes

> Les modèles `ml_linkage__delta_event_series*` sont rebuild quotidiennement alors que l'ingestion côté backend ne tourne qu'une fois par semaine. Résultat : entre deux ingestions, les mêmes lignes `add` étaient renvoyées jour après jour même si elles avaient déjà été appliquées à la base applicative, créant du bruit et un risque de retraitement inutile côté backend.

### 🔧 Changements
- Ajout d'une CTE `already_ingested_*` dans `ml_linkage__delta_event_series.sql` et `ml_linkage__delta_event_series_offer_link.sql` qui identifie les entités déjà présentes dans `applicative_database_event_series(_offer_link)` et non concernées par un `remove`/`update` du delta courant.
- Les lignes `add` correspondant à ces entités déjà ingérées sont désormais exclues de `added_delta_event_series(_offer_link)`.
- Mise à jour des docs (`description__ml_linkage__delta_event_series*.md`) pour préciser que les lignes `add` déjà ingérées sont exclues.

## Jira ticket number and/or notion link

_Aucun ticket_

### Type of change

- [x] Fix (non-breaking change which corrects expected behavior)

### 🧪 Comment tester
- Vérifier sur un run dbt que les `event_series_id` / `(event_series_id, offer_id)` déjà présents dans `applicative_database_event_series(_offer_link)` sans `remove`/`update` associé dans le delta courant ne réapparaissent plus dans `added_delta_event_series(_offer_link)`.
- Vérifier que les entités marquées `remove`/`update` restent bien traitées normalement (la CTE `already_ingested_*` les exclut volontairement).

---
**🧭 Review effort : 2/5** — changement localisé à 2 modèles dbt, logique de filtrage claire (NOT EXISTS), pas d'impact sur le schéma de sortie.
