### PR TITLE
(DE-4370) perf(pcreco): use timestamp partition field for source table pruning …

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/intermediate/pcreco/int_pcreco__past_offer_context_sink.sql
+++ b/orchestration/dags/data_gcp_dbt/models/intermediate/pcreco/int_pcreco__past_offer_context_sink.sql
@@ -34,7 +34,7 @@ with
             as scorer_ranking_model_display_name,
             reco_sink.jsonpayload.extra.context_extra_data.scorer.ranking.model_version
             as scorer_ranking_model_version,
-            date(reco_sink.jsonpayload.extra.date) as event_date,
+            date(reco_sink.timestamp) as event_date,
             case
                 when reco_sink.jsonpayload.extra.context like "similar_offer:%"
                 then "similar_offer"
@@ -118,11 +118,11 @@ with
 
             and (
                 {% if is_incremental() %}
-                    date(reco_sink.jsonpayload.extra.date) between date_sub(
+                    date(reco_sink.timestamp) between date_sub(
                         date("{{ ds() }}"), interval {{ var("lookback_days", 3) }} day
                     ) and date("{{ ds() }}")
                 {% else %}
-                    date(reco_sink.jsonpayload.extra.date)
+                    date(reco_sink.timestamp)
                     >= date_sub(date("{{ ds() }}"), interval 60 day)
                 {% endif %}
             )
@@ -133,7 +133,7 @@ with
                     reco_sink.jsonpayload.extra.user_id,
                     reco_sink.jsonpayload.extra.call_id,
                     reco_sink.jsonpayload.extra.offer_id
-                order by reco_sink.jsonpayload.extra.date desc
+                order by reco_sink.timestamp desc
             )
             = 1
     )


### PR DESCRIPTION
## 🎯 Changements effectués

> Le modèle `int_pcreco__past_offer_context_sink` filtrait la table source `run_googleapis_com_stderr` en utilisant `jsonpayload.extra.date` (un champ applicatif dans le payload JSON), qui ne correspond pas au champ de partition de BigQuery. BigQuery ne pouvait donc pas faire de partition pruning et devait scanner l'intégralité de la table (plusieurs téraoctets).
>
> Ce changement remplace ce champ par `reco_sink.timestamp`, qui est le vrai champ de partition de la table source, permettant à BigQuery de ne scanner que les partitions pertinentes.

### 🔧 Changements

- `int_pcreco__past_offer_context_sink.sql` : remplacement de `reco_sink.jsonpayload.extra.date` par `reco_sink.timestamp` dans :
  - Le calcul de `event_date` (colonne de partition de la table de destination)
  - Le filtre `WHERE` (incremental et full-refresh) pour activer le partition pruning sur la source
  - Le `ORDER BY` de la clause `QUALIFY` pour la déduplication

> La logique métier, les conditions de filtrage et les intervalles de dates restent strictement identiques.

### 🧪 Comment tester

- Lancer le modèle en mode incrémental et vérifier dans les query stats BigQuery que le nombre de bytes scannés est significativement réduit (pruning actif)
- Vérifier que `event_date` est correctement populé et cohérent avec les valeurs attendues

---
**🧭 Review effort : 2/5** — _Changement localisé sur un seul fichier SQL, logique inchangée, impact performance significatif._

**🗂️ Walkthrough**

| Fichier | Résumé |
|---|---|
| `models/intermediate/pcreco/int_pcreco__past_offer_context_sink.sql` | Remplace `jsonpayload.extra.date` par `timestamp` dans `event_date`, `WHERE` et `QUALIFY ORDER BY` |