### PR TITLE
(BSR) docs(agents): add dependency-vulnerability-pr skill

### DIFF
--- a/.agents/skills/dependency-vulnerability-pr/SKILL.md
+++ b/.agents/skills/dependency-vulnerability-pr/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: dependency-vulnerability-pr
+description: "Audit all Dependabot security alerts for a monorepo directory (e.g. ml_jobs), classify vulnerabilities into safe vs breaking upgrades, apply fixes across all sub-projects using uv, and open two PRs (one per class) following data team standards. Use this skill when the user wants to fix dependency vulnerabilities in bulk, mentions Dependabot alerts, or asks to clean up security issues across ml_jobs or similar multi-package directories. Relies on the vulnerability-fix and data-pr-workflow sub-skills."
+---
+
+# Dependency Vulnerability PR Skill
+
+This skill automates the full workflow of fixing Python dependency vulnerabilities across a multi-package directory in the monorepo: auditing via Dependabot, classifying by risk, applying fixes with `uv`, and opening two PRs via the data team workflow.
+
+Sub-skills used:
+- [`vulnerability-fix`](../vulnerability-fix/SKILL.md) — for per-project pyproject.toml edits and `uv lock` regeneration
+- [`data-pr-workflow`](../data-pr-workflow/SKILL.md) — for branch naming, commit format, PR creation, and Slack message
+
+---
+
+## When to Use This Skill
+
+- User wants to fix Dependabot / `uv audit` alerts in bulk across `ml_jobs` or another multi-package directory
+- User asks to "clean up security vulnerabilities" across a monorepo subset
+- User references one or more ticket IDs for a vulnerability remediation task
+- User wants two PRs: one for safe patches, one for breaking/major upgrades
+
+---
+
+## Step 0: Gather Prerequisites
+
+Ask the user for:
+1. **Scope directory** — which subdirectory to target (e.g. `jobs/ml_jobs`)
+2. **Ticket IDs** — two Jira/Linear tickets (one for safe PR, one for breaking PR), e.g. `DE-XXXX` and `DE-YYYY`
+3. **Reviewer** — who to tag in the Slack `#data-review` message
+
+---
+
+## Step 1: Fetch All Dependabot Alerts for the Scope
+
+Use the GitHub API via `gh` CLI to get all open alerts scoped to the target directory:
+
+```bash
+gh api repos/OWNER/REPO/dependabot/alerts --paginate \
+  -q '.[] | select(.state=="open") | select(.dependency.manifest_path | startswith("SCOPE_DIR")) | [
+    .dependency.package.name,
+    .security_vulnerability.vulnerable_version_range,
+    .security_vulnerability.first_patched_version.identifier,
+    .security_advisory.severity,
+    .security_advisory.ghsa_id
+  ] | @tsv' \
+  | tr '[:upper:]' '[:lower:]' | sort -u
+```
+
+Replace `OWNER/REPO` with the GitHub repo slug and `SCOPE_DIR` with the target path (e.g. `jobs/ml_jobs`).
+
+This gives a deduplicated, tab-separated list of: package, vulnerable range, first patched version, severity, GHSA ID.
+
+---
+
+## Step 2: Check Actual Locked Versions
+
+Before classifying, verify what versions are **currently locked** — the Dependabot alert may already be resolved:
+
+```bash
+# For each package of interest, grep all uv.lock files
+grep -r "name = \"PACKAGE_NAME\"" SCOPE_DIR/*/uv.lock -A1
+```
+
+Discard alerts where the locked version already satisfies the fix version.
+
+---
+
+## Step 3: Classify into Safe vs Breaking
+
+For each remaining alert, classify the required upgrade:
+
+### ✅ Safe (PR 1) — Same major version
+- Patch or minor bump within the same major: e.g. `3.1.x → 3.1.55`, `6.5.x → 6.5.7`
+- No major API changes expected
+- All jobs can be upgraded at once
+
+### ⚠️ Breaking (PR 2) — Major version jump or known rewrite boundary
+- Major version bump: e.g. `0.x → 1.x`, `4.x → 5.x`, `48.x → 49.x`
+- Known examples of rewrite boundaries: `starlette 0.x → 1.x`, `transformers 4.x → 5.x`
+- Each affected job should be smoke-tested after merge
+
+Build two separate fix lists before proceeding.
+
+---
+
+## Step 4: Apply Safe Fixes (PR 1)
+
+Follow the [`vulnerability-fix`](../vulnerability-fix/SKILL.md) skill for each project in scope:
+
+1. For each sub-project under the scope directory:
+   - Check if the package is a **direct** or **transitive** dependency in `pyproject.toml`
+   - Direct → update version spec in `[project] dependencies`
+   - Transitive → add/update entry in `[tool.uv] constraint-dependencies`
+2. After editing all `pyproject.toml` files, run `uv lock` for each sub-project:
+
+```bash
+for job in SCOPE_DIR/*/; do
+    job_name=$(basename "$job")
+    [[ "$job_name" == _* ]] && continue
+    echo "=== $job_name ===" && (cd "$job" && uv lock --no-progress 2>&1 | tail -3) && echo "OK" || echo "FAILED"
+done
+```
+
+3. Fix any `uv lock` failures (version conflicts, exact-pin collisions) before proceeding.
+
+**Tip**: If a direct dependency has an exact pin (`==`) that conflicts with a constraint, change it to a minimum bound (`>=`).
+
+---
+
+## Step 5: Create PR 1 (Safe Fixes)
+
+Follow the [`data-pr-workflow`](../data-pr-workflow/SKILL.md) skill:
+
+```bash
+# Create branch from master
+git checkout master && git pull
+git checkout -b DE-XXXX/fix-SCOPE-vulnerabilities-safe
+
+# Commit
+git add SCOPE_DIR/
+git commit -m "fix(SCOPE): patch transitive dependency vulnerabilities (non-breaking)
+
+<list each package and the CVE/GHSA IDs it resolves>"
+
+# Push and create PR
+git push origin DE-XXXX/fix-SCOPE-vulnerabilities-safe
+gh pr create \
+  --title "(DE-XXXX) fix(SCOPE): patch transitive dependency vulnerabilities (non-breaking)" \
+  --body "..." \
+  --base master
+```
+
+PR body should include a table of packages updated with before/after versions and CVE IDs.
+
+---
+
+## Step 6: Apply Breaking Fixes (PR 2)
+
+Start from master (not from PR 1):
+
+```bash
+git checkout master && git pull
+git checkout -b DE-YYYY/fix-SCOPE-vulnerabilities-breaking
+```
+
+Apply the same [`vulnerability-fix`](../vulnerability-fix/SKILL.md) process as Step 4, but only for the breaking-classified packages and only for the sub-projects that are affected (check locked versions to determine which jobs need upgrading).
+
+Re-run `uv lock` for all sub-projects and verify no failures.
+
+---
+
+## Step 7: Create PR 2 (Breaking Fixes)
+
+```bash
+git add SCOPE_DIR/
+git commit -m "fix(SCOPE): update major-version dependencies with security vulnerabilities
+
+<list each package with major version jump, affected sub-projects, and risk notes>"
+
+git push origin DE-YYYY/fix-SCOPE-vulnerabilities-breaking
+gh pr create \
+  --title "(DE-YYYY) fix(SCOPE): update major-version dependencies with security vulnerabilities" \
+  --body "..." \
+  --base master
+```
+
+PR body must include:
+- A table of packages with before/after versions and affected sub-projects
+- A risk note for each major-version jump
+- A testing note: which sub-projects need end-to-end validation after merge
+
+---
+
+## Step 8: Generate Slack Messages
+
+Following [`data-pr-workflow`](../data-pr-workflow/SKILL.md) Step 7:
+
+```
+[REVIEW] (DE-XXXX) Security patch: non-breaking vuln fixes across SCOPE @Reviewer | Complexity: 3 | Time: ~15mn
+```
+
+```
+[REVIEW] (DE-YYYY) Security patch: breaking major-version dep upgrades across SCOPE @Reviewer | Complexity: 5 | Time: >20mn
+```
+
+Post both to `#data-review`. PR 2 should only be merged **after** PR 1 and after the affected jobs have been validated.
+
+---
+
+## Environment Context
+
+**Local machines are macOS; CI/CD and deployment runners are Linux (x86_64).**
+
+This asymmetry is the root cause of most constraint failures that only appear in CI:
+
+- `uv lock` resolves successfully on macOS locally, but fails on Linux CI because some packages ship platform-specific wheels with different dependency constraints
+- CUDA/GPU variants (e.g. `torch+cu128`) are only pulled on Linux and often carry additional hard constraints (e.g. `torch>=2.11.0+cu128` requires `setuptools<82`) that are invisible when locking on macOS
+- When `uv lock` is run locally, always validate against the Linux split explicitly by checking `environments` in `[tool.uv]` — if only `sys_platform == 'linux'` is listed, local macOS resolution may silently skip incompatible constraints
+- If CI fails with "No solution found for split `python_full_version == '3.x.*' and sys_platform == 'linux'`", the conflict is a Linux-only constraint that was not caught locally
+
+**When adding a new constraint**, always check whether the affected package has a Linux-specific wheel with tighter requirements before applying it globally. Known conflicts:
+
+| Constraint | Conflicting Linux dep | Reason |
+|---|---|---|
+| `setuptools >= 83.0.0` | `torch>=2.11.0+cu128` | torch cu128 hard-requires `setuptools<82` |
+| `transformers >= 5.x` | `recommenders>=1.2.1` | recommenders hard-requires `transformers<5` |
+
+In both cases: skip the constraint for the affected job, document the trade-off in a comment, and accept the unresolved CVE as a known limitation.
+
+**Other operational notes:**
+
+| Situation | Action |
+|---|---|
+| Alert already resolved in lockfile | Skip — grep actual locked version before applying any fix |
+| Some jobs have 0.x, others 1.x of same package | Split: safe for jobs already on 1.x, breaking for jobs on 0.x |
+| `uv-secure` pre-commit hook warns but doesn't block | If remaining alerts are all for PR 2 packages, the commit is safe to proceed |
+| Dependabot count increases after PR creation | GitHub rescans on push; new alerts may be for different files or newly published CVEs |
+| `uv lock` fails with exact-pin conflict | Change direct dep exact pin (`==`) to minimum bound (`>=`) |


### PR DESCRIPTION
## Summary
Adds a new agent skill `dependency-vulnerability-pr` that automates the full workflow for fixing Python dependency vulnerabilities in bulk across a multi-package monorepo directory (e.g. `ml_jobs`).

The skill was built from the hands-on work done to remediate 700+ Dependabot alerts in `ml_jobs` (see #5512 and #5513).

## Changes
- New skill: `.agents/skills/dependency-vulnerability-pr/SKILL.md`
- Covers 8-step workflow: fetch alerts → check locked versions → classify safe/breaking → apply fixes → create 2 PRs → Slack messages
- References `vulnerability-fix` and `data-pr-workflow` as sub-skills
- Includes **Environment Context** section explaining the macOS/Linux asymmetry (root cause of most CI failures when testing constraint updates locally)
- Documents known unresolvable conflicts: `torch cu128` vs `setuptools>=83`, `recommenders` vs `transformers>=5`

## Related
- Companion PRs: #5512 (DE-4355), #5513 (DE-4356)

## Testing
Skill was exercised end-to-end during the ml_jobs vulnerability remediation session.