### PR TITLE
(BSR) fix(ci): prevent script injection via github.actor in workflows

### DIFF
--- a/.github/workflows/reusable_dbt_workflow.yml
+++ b/.github/workflows/reusable_dbt_workflow.yml
@@ -206,8 +206,9 @@ jobs:
         env:
           PASSDIRECTOR_SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.PASSDIRECTOR_SLACK_BOT_TOKEN }}
           NOTIF_CHANNEL_ID: ${{ inputs.NOTIF_CHANNEL_ID }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           passdirector slack post \
             --channel "$NOTIF_CHANNEL_ID" \
             --message "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|La compilation dbt a échoué>" \
-            --github-actor "${{ github.actor }}"
+            --github-actor "$GITHUB_ACTOR"

--- a/.github/workflows/reusable_deploy_airflow.yml
+++ b/.github/workflows/reusable_deploy_airflow.yml
@@ -305,13 +305,16 @@ jobs:
         env:
           PASSDIRECTOR_SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.PASSDIRECTOR_SLACK_BOT_TOKEN }}
           AIRFLOW_NAME: ${{ inputs.AIRFLOW_NAME }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          JOB_STATUS: ${{ job.status }}
+          NOTIF_CHANNEL_ID: ${{ vars.NOTIF_CHANNEL_ID }}
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
+          if [ "$JOB_STATUS" = "success" ]; then
             EMOJI="✅"
           else
             EMOJI="❌"
           fi
           passdirector slack post \
-            --channel "${{ vars.NOTIF_CHANNEL_ID }}" \
+            --channel "$NOTIF_CHANNEL_ID" \
             --message "${EMOJI} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Airflow déployé> sur l'environnement $AIRFLOW_NAME" \
-            --github-actor "${{ github.actor }}"
+            --github-actor "$GITHUB_ACTOR"

--- a/.github/workflows/reusable_deploy_mkdocs.yml
+++ b/.github/workflows/reusable_deploy_mkdocs.yml
@@ -107,8 +107,9 @@ jobs:
         env:
           PASSDIRECTOR_SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.PASSDIRECTOR_SLACK_BOT_TOKEN }}
           NOTIF_CHANNEL_ID: ${{ inputs.NOTIF_CHANNEL_ID }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           passdirector slack post \
             --channel "$NOTIF_CHANNEL_ID" \
             --message ":fire: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deploy Job échoué> :no_entry:" \
-            --github-actor "${{ github.actor }}"
+            --github-actor "$GITHUB_ACTOR"

--- a/.github/workflows/reusable_job_test.yml
+++ b/.github/workflows/reusable_job_test.yml
@@ -79,8 +79,9 @@ jobs:
           PASSDIRECTOR_SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.PASSDIRECTOR_SLACK_BOT_TOKEN }}
           NOTIF_CHANNEL_ID: ${{ inputs.NOTIF_CHANNEL_ID }}
           JOB_PATH: ${{ inputs.JOB_PATH }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           passdirector slack post \
             --channel "$NOTIF_CHANNEL_ID" \
             --message ":fire: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Les tests sur le job $JOB_PATH ont échoués> :no_entry:" \
-            --github-actor "${{ github.actor }}"
+            --github-actor "$GITHUB_ACTOR"

--- a/.github/workflows/reusable_linter.yml
+++ b/.github/workflows/reusable_linter.yml
@@ -68,8 +68,9 @@ jobs:
         env:
           PASSDIRECTOR_SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.PASSDIRECTOR_SLACK_BOT_TOKEN }}
           NOTIF_CHANNEL_ID: ${{ inputs.NOTIF_CHANNEL_ID }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           passdirector slack post \
             --channel "$NOTIF_CHANNEL_ID" \
             --message ":fire: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Linter job échoué> :no_entry:" \
-            --github-actor "${{ github.actor }}"
+            --github-actor "$GITHUB_ACTOR"

--- a/.github/workflows/reusable_test_orchestration.yml
+++ b/.github/workflows/reusable_test_orchestration.yml
@@ -88,8 +88,9 @@ jobs:
         env:
            PASSDIRECTOR_SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.PASSDIRECTOR_SLACK_BOT_TOKEN }}
            NOTIF_CHANNEL_ID: ${{ inputs.NOTIF_CHANNEL_ID }}
+           GITHUB_ACTOR: ${{ github.actor }}
         run: |
           passdirector slack post \
             --channel "$NOTIF_CHANNEL_ID" \
             --message "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Les tests d'orchestration ont échoués>" \
-            --github-actor "${{ github.actor }}"
+            --github-actor "$GITHUB_ACTOR"


### PR DESCRIPTION
## Summary
Fixes actionlint security warnings by passing `github.actor` through environment variables instead of using it directly in inline scripts. This prevents potential script injection attacks.
## Changes
- **reusable_dbt_workflow.yml**: Added `GITHUB_ACTOR` env var
- **reusable_deploy_airflow.yml**: Added `GITHUB_ACTOR` and `JOB_STATUS` env vars, moved `NOTIF_CHANNEL_ID` to env
- **reusable_deploy_mkdocs.yml**: Added `GITHUB_ACTOR` env var
- **reusable_job_test.yml**: Added `GITHUB_ACTOR` env var
- **reusable_linter.yml**: Added `GITHUB_ACTOR` env var
- **reusable_test_orchestration.yml**: Added `GITHUB_ACTOR` env var
## Testing
- All 6 actionlint errors resolved
- No functional change: same values passed via env vars instead of inline expressions