### PR TITLE
(BSR) docs(dbt): wire up mrt_global__collective_offer_domain documentation

### DIFF
--- a/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/mart/global/description__mrt_global__collective_offer_domain.md
+++ b/orchestration/dags/data_gcp_dbt/models/_dbt_docs/models/mart/global/description__mrt_global__collective_offer_domain.md
@@ -9,6 +9,12 @@ description: Description of the `mrt_global__collective_offer_domain` table.
 
 The `mrt_global__collective_offer_domain` table is designed to store the list of the educational domains associated to collective offers.
 
+One row is one (collective offer, educational domain) pair: an offer can carry several domains, so counting offers requires `COUNT(DISTINCT collective_offer_id)` — a plain `COUNT(*)` counts pairs, not offers.
+
+`collective_offer_id` holds ids from two different entities: the model is a `UNION ALL` of `collective_offer_domain` (real offers) and `collective_offer_template_domain`, whose `collective_offer_template_id` is aliased into the same column. A template is a reusable draft, not a bookable offer, so joining directly to `mrt_global__collective_offer` matches only part of the rows and silently drops the template ones — filter to the population you actually mean.
+
+The referential is specific to the collective (EAC) side: there is no equivalent governed domain taxonomy for individual offers, so this table cannot answer "by cultural domain" questions about individual bookings.
+
 {% enddocs %}
 
 Collective offers can be related to several educational domain. The table is the corresponding table used to find the exhautive educational domain list of each collective offer.

--- a/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__collective_offer_domain.yml
+++ b/orchestration/dags/data_gcp_dbt/models/mart/global/_schema/mrt_global__collective_offer_domain.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models:
+  - name: mrt_global__collective_offer_domain
+    description: "{{ doc('description__mrt_global__collective_offer_domain') }}"
+    columns:
+      - name: collective_offer_id
+        description: "{{ doc('column__collective_offer_id') }}"
+      - name: educational_domain_id
+        description: "{{ doc('column__educational_domain_id') }}"
+      - name: educational_domain_name
+        description: "{{ doc('column__educational_domain_name') }}"


### PR DESCRIPTION
The description doc already existed but was ORPHANED: without a _schema/*.yml referencing it, dbt attaches nothing to the model, so the manifest carries no description and no documented columns — the doc was written and then invisible to every downstream consumer (dbt docs, the semantic layer, agent retrieval).

Adds the missing schema file, wiring the existing description block and the three already-defined column doc blocks (column__collective_offer_id, column__educational_domain_id, column__educational_domain_name). No new glossary entries needed.

Also documents two traps the description omitted, both read from the model SQL:
- the model is a UNION ALL of collective_offer_domain and collective_offer_template_domain, so collective_offer_id mixes offer ids and TEMPLATE ids; a naive join to mrt_global__collective_offer silently drops the template rows;
- one row per (offer, domain) pair, so COUNT(DISTINCT collective_offer_id) is required to count offers.

Context: the table backs 40 Metabase cards / 7.9k views over 3 months but is absent from the Cassis ontology because it has no manifest documentation to enrich from. This unblocks placing it in the collectif-eac domain.

# PR template

## Select PR template in preview mode

* [Hotfix](?expand=1&template=Hotfix_template.md)
* [DA](?expand=1&template=DA_ticket_template.md)
* [DE](?expand=1&template=DE_ticket_template.md)
* [DS](?expand=1&template=DS_ticket_template.md)
* [MEP](?expand=1&template=MEP_template.md)

## PR title format (except for MEP)

There is a linter on the PR title format. Please respect the following format:

<details>
<summary>(ticket) type(topic): comment</summary>

* ticket surrounded by parenthesis, with optionnaly a hyphen followed by one or more digits (e.g., -1234). The first part must be one of the following strings:
  * DA
  * DE
  * AE
  * DS
  * HF
  * BSR
  * PC

* type :
The second part to specify the type of change one of the following :
  * build
  * lint
  * ci
  * docs
  * feat
  * fix
  * perf
  * refactor
  * test
  * chore
  * dbt

* topic within parenthesis: 1 word e.g., (dag)

* comment: tell us your life

examples:

* :white_check_mark: (DE-124) refactor(firebase): update source field
* :x: (DE-124) refactor (firebase): update source field **(space between type and topic)**
* :x: (DE-124) airflow(firebase): update source fiedd in DAG **(wrong type)**
* :x: (DE-124) (DE-124) refactor(firebase refacto): update source field **(topic in two words)**
* :white_check_mark: (BSR) docs(github): add PR title valid format in template

</details>

<!-- Markdown tips:

To tick boxe replace [ ] with [x]

 -->

 <!--
TO DO: check with repo admin : [https://passculture.atlassian.net/browse/PC-<num>](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources)

JIRA-replace_with_ticket_number

[Notion-link](paste within parenthesis)
-->
